### PR TITLE
Additional client_registration_types MAY be defined and used

### DIFF
--- a/openid-federation-1_0.xml
+++ b/openid-federation-1_0.xml
@@ -1273,6 +1273,7 @@
               are
               <spanx style="verb">automatic</spanx>
               and <spanx style="verb">explicit</spanx>.
+	      Additional values MAY be defined and used.
             </t>
           </list>
         </t>
@@ -1351,6 +1352,7 @@
               Federation-type values defined by this specification are
               <spanx style="verb">automatic</spanx>
               and <spanx style="verb">explicit</spanx>.
+	      Additional values MAY be defined and used.
             </t>
             <t hangText="federation_registration_endpoint">
               <vspace/>
@@ -9320,6 +9322,7 @@ Host: op.umu.se
         Torsten Lodderstedt,
         Francesco Marino,
         Roberto Polli,
+	Justin Richer,
         Jouke Roorda,
         Nat Sakimura,
         Mischa Sallé,
@@ -9349,6 +9352,10 @@ Host: op.umu.se
 	    to the repository https://github.com/openid/federation.
 	    Issue numbers before this draft are from the Bitbucket repository.
 	    Issue numbers starting with this draft are from the GitHub repository.
+	  </t>
+	  <t>
+	    Clarified that additional <spanx style="verb">client_registration_types</spanx>
+	    MAY be defined and used.
 	  </t>
 	</list>
       </t>

--- a/openid-federation-1_0.xml
+++ b/openid-federation-1_0.xml
@@ -1352,7 +1352,7 @@
               Federation-type values defined by this specification are
               <spanx style="verb">automatic</spanx>
               and <spanx style="verb">explicit</spanx>.
-	      Additional values MAY be defined and used.
+	      Additional values MAY be defined and used, without restriction by this specification.
             </t>
             <t hangText="federation_registration_endpoint">
               <vspace/>

--- a/openid-federation-1_0.xml
+++ b/openid-federation-1_0.xml
@@ -1273,7 +1273,7 @@
               are
               <spanx style="verb">automatic</spanx>
               and <spanx style="verb">explicit</spanx>.
-	      Additional values MAY be defined and used.
+	      Additional values MAY be defined and used, without restriction by this specification.
             </t>
           </list>
         </t>


### PR DESCRIPTION
Added a clarification suggested by @jricher in his role as Designated Expert for the IANA OAuth Dynamic Client Registration Metadata registry.