### PR TITLE
Corrected Usage Location for IANA error registrations

### DIFF
--- a/openid-federation-1_0.xml
+++ b/openid-federation-1_0.xml
@@ -7169,7 +7169,7 @@ HTTP/1.1 302 Found
             <?rfc subcompact="yes"?>
             <list style="symbols">
               <t>Name: missing_trust_anchor</t>
-              <t>Usage Location: Authorization Request</t>
+              <t>Usage Location: authorization endpoint</t>
               <t>Protocol Extension: OpenID Federation</t>
               <t>
                 Change Controller: OpenID Foundation Artifact Binding Working Group - openid-specs-ab@lists.openid.net
@@ -7180,7 +7180,7 @@ HTTP/1.1 302 Found
           <t>
             <list style="symbols">
               <t>Name: validation_failed</t>
-              <t>Usage Location: Authorization Request</t>
+              <t>Usage Location: authorization endpoint</t>
               <t>Protocol Extension: OpenID Federation</t>
               <t>
                 Change Controller: OpenID Foundation Artifact Binding Working Group - openid-specs-ab@lists.openid.net
@@ -9363,6 +9363,9 @@ Host: op.umu.se
 	  </t>
 	  <t>
 	    Fixed #19: Clarified that Federation Entities publish their public keys.
+	  </t>
+	  <t>
+	    Corrected Usage Location values in IANA "OAuth Extensions Error Registry" registrations.
 	  </t>
 	</list>
       </t>


### PR DESCRIPTION
As suggested by @hannestschofenig during his review in his role of Designated Expert for the IANA "OAuth Extensions Error Registry" registry.