### PR TITLE
fix: the parameters sub and iss must not be set with the same value at the fetch endpoint

### DIFF
--- a/openid-federation-1_0.xml
+++ b/openid-federation-1_0.xml
@@ -9333,6 +9333,7 @@ Host: op.umu.se
         Takahiko Kawasaki,
         Torsten Lodderstedt,
         Francesco Marino,
+        John Melati,
         Roberto Polli,
 	Justin Richer,
         Jouke Roorda,

--- a/openid-federation-1_0.xml
+++ b/openid-federation-1_0.xml
@@ -3737,10 +3737,15 @@
               <t hangText="sub">
                 <vspace/>
                 OPTIONAL. The Entity Identifier of the subject
-                for which the Entity Statement is being requested. If this
-                parameter is omitted, it is considered to be the same as the
-                issuer and indicates a request for a self-signed
-                Entity Configuration.
+                for which the Entity Statement is being requested.
+                It MUST NOT set
+                with the same value as <spanx style="verb">iss</spanx>,
+                as a Federation Entity cannot be its own Subordinate.
+                If the request parameters <spanx style="verb">iss</spanx>
+                and <spanx style="verb">sub</spanx> have the same
+                Entity Identifier, the response MUST return an
+                <spanx style="verb">invalid_request</spanx>
+                error with a 400 status code.
               </t>
             </list>
           </t>
@@ -9347,6 +9352,17 @@ Host: op.umu.se
 
     <section anchor="History" title="Document History">
       <t>[[ To be removed from the final specification ]]</t>
+
+
+      <t>
+	-38
+	<list style="symbols">
+	  <t>
+	    Fixed #30: the parameters sub and iss must not be set with the same value
+      at the fetch endpoint.
+	  </t>
+	</list>
+      </t>
 
       <t>
 	-37


### PR DESCRIPTION
This PR resolves https://github.com/openid/federation/issues/30