### PR TITLE
Preventing use of Request Object for private_key_jwt client authentication

### DIFF
--- a/openid-federation-1_0.xml
+++ b/openid-federation-1_0.xml
@@ -5724,9 +5724,8 @@ Content-Type: application/json
                 </t>
                 <t hangText="sub">
                   <vspace/>
-                  MUST NOT be present. This, together with the value of
-                  <spanx style="verb">aud</spanx>,
-                  prevent reuse of the statement for
+                  MUST NOT be present.
+                  This prevents reuse of the statement for
                   <spanx style="verb">private_key_jwt</spanx>
                   client authentication.
                 </t>
@@ -9359,6 +9358,7 @@ Host: op.umu.se
       <t>
         The authors wish to acknowledge the contributions of the following
         individuals and organizations to this specification:
+	Marcus Almgren,
         Pasquale Barbaro,
      	Brian Campbell,
         David Chadwick,
@@ -9385,6 +9385,7 @@ Host: op.umu.se
         Giada Sciarretta,
         Amir Sharif,
 	Sean Turner,
+	Tim Würtele,
         Kristina Yasuda,
         and
         the JRA3T3 task force of GEANT4-2.
@@ -9402,6 +9403,10 @@ Host: op.umu.se
 	  </t>
 	  <t>
 	    Endpoint URLs are not form-urlencoded in JSON metadata parameter values.
+	  </t>
+	  <t>
+	    Fixed #46: Corrected statment about preventing use of Request Object
+	    for <spanx style="verb">private_key_jwt</spanx> client authentication.
 	  </t>
 	</list>
       </t>


### PR DESCRIPTION
Fixes #46 

Cc: @SECtim @malmgren01DF