### PR TITLE
Simplified use of PAR for request authentication

### DIFF
--- a/openid-federation-1_0.xml
+++ b/openid-federation-1_0.xml
@@ -1407,21 +1407,6 @@
               Registration as described in <xref target="explicit"/>,
               then this claim is REQUIRED.
             </t>
-
-            <t hangText="request_authentication_signing_alg_values_supported">
-              <vspace/>
-              OPTIONAL.
-              JSON array containing a list of the supported
-              <xref target="RFC7515">JWS</xref> algorithms
-              (<spanx style="verb">alg</spanx> values)
-              for signing the <xref target="RFC7519">JWT</xref>
-              used in the Request Object of the OpenID Connect authentication request
-	      or in the <spanx style="verb">private_key_jwt</spanx> JWT
-	      of a pushed authorization request to the OP.
-              No default algorithms are implied if this entry is omitted.
-              Servers SHOULD support <spanx style="verb">RS256</spanx>.
-              The value <spanx style="verb">none</spanx> MUST NOT be used.
-            </t>
           </list>
         </t>
 
@@ -1476,7 +1461,11 @@
             "private_key_jwt"
          ],
          "pushed_authorization_request_endpoint":"https://op.umu.se/openid/par",
-         "request_authentication_signing_alg_values_supported": [
+         "request_object_signing_alg_values_supported": [
+            "ES256",
+            "RS256"
+         ],
+         "token_endpoint_auth_signing_alg_values_supported": [
             "ES256",
             "RS256"
          ]
@@ -7139,25 +7128,6 @@ HTTP/1.1 302 Found
           <t>
             <list style='symbols'>
               <t>
-                Metadata Name: <spanx style="verb">request_authentication_signing_alg_values_supported</spanx>
-              </t>
-              <t>
-                Metadata Description:
-                JSON array containing the JWS signing algorithms
-                supported for the signature on
-                the JWT used to authenticate the request
-              </t>
-              <t>
-                Change Controller: OpenID Foundation Artifact Binding Working Group - openid-specs-ab@lists.openid.net
-              </t>
-              <t>
-                Specification Document(s): <xref target="OP_metadata"/> of this specification
-              </t>
-            </list>
-          </t>
-          <t>
-            <list style='symbols'>
-              <t>
                 Metadata Name: <spanx style="verb">signed_jwks_uri</spanx>
               </t>
               <t>
@@ -9742,8 +9712,10 @@ Host: op.umu.se
 	  </t>
 	  <t>
 	    Fixed #34: Deleted
-	    <spanx style="verb">request_authentication_methods_supported</spanx>
-	    and replaced with the use of standard PAR metadata values.
+	    <spanx style="verb">request_authentication_methods_supported</spanx> and
+	    <spanx style="verb">request_authentication_signing_alg_values_supported</spanx>
+	    and replaced with the use of standard Request Object
+	    and PAR metadata values.
 	    Also restricted PAR authentication methods to those
 	    performing signing with the RP's keys.
 	  </t>

--- a/openid-federation-1_0.xml
+++ b/openid-federation-1_0.xml
@@ -5987,7 +5987,7 @@ GET /authorize?
             <t>
               <xref target="RFC9126">Pushed Authorization Requests</xref>
               provide an
-              interoperable way to push an authentication request parameters
+              interoperable way to push authentication request parameters
               directly to the AS in exchange for a one-time-use
               <spanx style="verb">request_uri</spanx>.
 	      The standard PAR metadata parameters are used in the

--- a/openid-federation-1_0.xml
+++ b/openid-federation-1_0.xml
@@ -1232,6 +1232,21 @@
           All Federation Entities MAY publish a
 	      <spanx style="verb">federation_historical_keys_endpoint</spanx>.
 	    </t>
+
+            <t hangText="endpoint_authentication_signing_alg_values_supported">
+              <vspace/>
+              OPTIONAL.
+              JSON array containing a list of the supported
+              <xref target="RFC7515">JWS</xref> algorithms
+              (<spanx style="verb">alg</spanx> values)
+              for signing the <xref target="RFC7519">JWT</xref>
+              used for <spanx style="verb">private_key_jwt</spanx>
+	      when authenticating to federation endpoints,
+	      as described in <xref target="ClientAuthentication"/>.
+              No default algorithms are implied if this entry is omitted.
+              Servers SHOULD support <spanx style="verb">RS256</spanx>.
+              The value <spanx style="verb">none</spanx> MUST NOT be used.
+            </t>
           </list>
         </t>
 	<t>
@@ -1379,44 +1394,6 @@
               then this claim is REQUIRED.
             </t>
 
-            <t hangText="pushed_authentication_methods_supported">
-              <vspace/>
-              OPTIONAL.
-	      A Pushed Authorization Request (PAR) <xref target="RFC9126"/>
-	      can be used with Automatic Registration,
-	      as described in <xref target="authn-request"/>.
-	      Some OAuth 2.0 client authentication methods can be used at the
-	      <spanx style="verb">pushed_authorization_request_endpoint</spanx>
-	      to achieve request authentication.
-	      They are the subset of those listed in the
-	      IANA "OAuth Token Endpoint Authentication Methods" registry <xref target="IANA.OAuth.Parameters"/>
-	      that perform client authentication by proving possession of a private key.
-	      The <spanx style="verb">pushed_authentication_methods_supported</spanx>
-	      metadata value lists the client authentication methods
-	      supported by the OP that can be used in this manner.
-	      Its value is a JSON array of supported client authentication methods.
-	      Values that MAY be used are:
-              <list style="hanging">
-                <t hangText="private_key_jwt">
-                  <vspace/>
-                  This client authentication method is described in Section 9 of
-                  <xref target="OpenID.Core">OpenID Connect Core 1.0</xref>.
-                  When <spanx style="verb">private_key_jwt</spanx> is used,
-		  the audience of the signed JWT MUST be
-                  the Authorization Server's Entity Identifier.
-                </t>
-                <t hangText="self_signed_tls_client_auth">
-                  <vspace/>
-                  This client authentication method is described in Section 2.2 of
-                  <xref target="RFC8705"/>.
-                </t>
-              </list>
-	      <vspace blankLine="1"/>
-	      In both cases, the signing key MUST be one of the keys
-	      in the RP's JWK Set published in its metadata.
-	      Additional pushed authentication methods MAY be defined and used.
-	    </t>
-
             <t hangText="request_authentication_signing_alg_values_supported">
               <vspace/>
               OPTIONAL.
@@ -1424,9 +1401,9 @@
               <xref target="RFC7515">JWS</xref> algorithms
               (<spanx style="verb">alg</spanx> values)
               for signing the <xref target="RFC7519">JWT</xref>
-              used in the Request Object
-              contained in the request parameter of an authorization request or
-              in the <spanx style="verb">private_key_jwt</spanx> of a pushed authorization request.
+              used in the Request Object of the OpenID Connect authentication request
+	      or in the <spanx style="verb">private_key_jwt</spanx> JWT
+	      of a pushed authorization request to the OP.
               No default algorithms are implied if this entry is omitted.
               Servers SHOULD support <spanx style="verb">RS256</spanx>.
               The value <spanx style="verb">none</spanx> MUST NOT be used.
@@ -1485,10 +1462,6 @@
             "private_key_jwt"
          ],
          "pushed_authorization_request_endpoint":"https://op.umu.se/openid/par",
-         "pushed_authentication_methods_supported": {
-            "private_key_jwt",
-            "self_signed_tls_client_auth"
-         ],
          "request_authentication_signing_alg_values_supported": [
             "ES256",
             "RS256"
@@ -5997,17 +5970,28 @@ GET /authorize?
             <t>
               <xref target="RFC9126">Pushed Authorization Requests</xref>
               provide an
-              interoperable way to push a Request Object
-              directly to the AS in exchange for a
+              interoperable way to push an authorization request
+              directly to the AS in exchange for a one-time-use
               <spanx style="verb">request_uri</spanx>.
+	      The standard PAR metadata parameters are used in the
+	      RP and OP metadata to indicate its use.
             </t>
+	    <t>
+	      When used with OpenID Federation,
+	      a Request Object MUST be sent to the PAR endpoint,
+	      signed with one of the RPs private keys.
+	      The corresponding public key MUST be in the RP's JWK Set.
+	      Furthermore, when used with OpenID Federation,
+	      the client authentication methods for the PAR endpoint
+	      are restricted to those proving possession of a private key.
+	      Likewise, the corresponding public key MUST be in the RP's JWK Set.
+	    </t>
             <t>
-              There are four applicable authentication methods:
+              The two applicable PAR client authentication methods are:
               <list style="symbols">
                 <t>
 		  JWT Client authentication, as described
-                  for <spanx style="verb">private_key_jwt</spanx> in Section 9
-                  of
+                  for <spanx style="verb">private_key_jwt</spanx> in Section 9 of
                   <xref target="OpenID.Core">OpenID Connect Core 1.0</xref>.
                 </t>
                 <t>
@@ -6017,27 +6001,16 @@ GET /authorize?
                   the value of an <spanx style="verb">x5c</spanx>
                   claim for one key in the JWK Set describing
                   the RP's keys.
-                </t>
-                <t>
-                  mTLS using public key infrastructure (PKI),
-		  as described in Section 2.1 of <xref target="RFC8705"/>.
-                </t>
-                <t>
-                  A Request Object, as described in
-                  <xref target="UsingAuthzRequestObject"/>
-                  and <xref target="trust_chain_authz"/>.
+		  In this case, the server MUST omit certificate chain validation.
                 </t>
               </list>
-              Note that if mTLS is used, TLS client authentication MUST be
-              configured and, in the case of self-signed certificates, the server must
-              omit the certificate chain validation.
             </t>
             <figure>
             <preamble>
-	      Using the example above, a Pushed Authorization Request could look like this:
+	      A Pushed Authorization Request to the OP could look like this:
 	    </preamble>
 	    <name>
-	      Pushed Authorization Request
+	      Pushed Authorization Request to the OP
 	    </name>
               <artwork><![CDATA[
 POST /par HTTP/1.1
@@ -6094,7 +6067,7 @@ request=eyJhbGciOiJSUzI1NiIsImtpZCI6Ik5fX0Q5OEl2QjhOYWUta3dBNm5yT3QtaXBU
               </t>
               <t>
                 Once the OP has the RP's metadata, it MUST verify the client
-		using the keys published for the
+		is using the keys published for the
 		<spanx style="verb">openid_relying_party</spanx>
 		Entity Type Identifier.
 		If the RP does not verify, the OP MUST reject the request.
@@ -6108,30 +6081,15 @@ request=eyJhbGciOiJSUzI1NiIsImtpZCI6Ik5fX0Q5OEl2QjhOYWUta3dBNm5yT3QtaXBU
                     signature of the signed JWT using the key material published
                     by the RP in its metadata. If the authentication is
                     successful, then the registration is valid.
-                  </t>
-                  <t hangText="tls_client_auth">
-                    <vspace/>
-                    If the certificate used is not self-signed, it MUST first be
-                    validated as chaining to a trusted root.
-		    (The selection of trusted roots is outside of this trust model.)
-                    <vspace blankLine="1"/>
-                    The RP metadata MUST contain exactly one of the five members listed in
-                    Section 2.1.2 of <xref target="RFC8705"/>.
-                    For example, if the
-		    <spanx style="verb">tls_client_auth_san_dns</spanx> member
-		    is specified with a value of <spanx style="verb">host.example.com</spanx>,
-		    the certificate would only match for authentication
-                    if that DNS name is present in the Subject Alternative Name (SAN)
-                    of the certificate.
+		    The audience of the signed JWT MUST be
+		    the Authorization Server's Entity Identifier.
                   </t>
                   <t hangText="self_signed_tls_client_auth">
                     <vspace/>
-                    If mTLS is used with a self-signed
-                    certificate, then the certificate MUST be present as the
-                    value
-                    of an <spanx style="verb">x5c</spanx>
-                    claim for a key in the JWK Set containing the RP's
-                    keys.
+                    If mTLS is used with a self-signed certificate,
+		    then the certificate MUST be present as the
+                    value of an <spanx style="verb">x5c</spanx>
+                    claim for a key in the JWK Set containing the RP's keys.
                   </t>
                 </list>
               </t>
@@ -7153,23 +7111,6 @@ HTTP/1.1 302 Found
               <t>
                 Metadata Description:
                 Federation Registration Endpoint
-              </t>
-              <t>
-                Change Controller: OpenID Foundation Artifact Binding Working Group - openid-specs-ab@lists.openid.net
-              </t>
-              <t>
-                Specification Document(s): <xref target="OP_metadata"/> of this specification
-              </t>
-            </list>
-          </t>
-          <t>
-            <list style='symbols'>
-              <t>
-                Metadata Name: <spanx style="verb">pushed_authentication_methods_supported</spanx>
-              </t>
-              <t>
-                Metadata Description:
-                Pushed authentication methods supported
               </t>
               <t>
                 Change Controller: OpenID Foundation Artifact Binding Working Group - openid-specs-ab@lists.openid.net
@@ -9777,12 +9718,15 @@ Host: op.umu.se
 	-40
 	<list style="symbols">
 	  <t>
-	    Fixed #34:
-	    Replaced <spanx style="verb">request_authentication_methods_supported</spanx>
-	    with <spanx style="verb">pushed_authentication_methods_supported</spanx>.
+	    Fixed #34: Deleted
+	    <spanx style="verb">request_authentication_methods_supported</spanx>
+	    and replaced with the use of standard PAR metadata values.
+	    Also restricted PAR authentication methods to those
+	    performing signing with the RP's keys.
 	  </t>
 	  <t>
-	    Fixed #98: Required audience when using <spanx style="verb">private_key_jwt</spanx>
+	    Fixed #98: Required audience when using
+	    <spanx style="verb">private_key_jwt</spanx>
 	    to be the Authorization Server's Entity Identifier.
 	  </t>
 	</list>

--- a/openid-federation-1_0.xml
+++ b/openid-federation-1_0.xml
@@ -87,7 +87,7 @@
       </address>
     </author>
 
-    <date day="9" month="October" year="2024"/>
+    <date day="17" month="October" year="2024"/>
 
     <workgroup>OpenID Connect Working Group</workgroup>
 
@@ -231,9 +231,15 @@
         <t>
           This specification uses the terms "Claim",
           "Claim Name", "Claim Value", "JSON Web Token (JWT)", and "JWT Claims Set"
-          defined by <xref target="RFC7519">JSON Web Token (JWT)</xref>
-          and the terms "OpenID Provider (OP)" and "Relying Party (RP)" defined
-          by <xref target="OpenID.Core">OpenID Connect Core 1.0</xref>.
+          defined by <xref target="RFC7519">JSON Web Token (JWT)</xref>,
+          the terms "OpenID Provider (OP)" and "Relying Party (RP)" defined
+          by <xref target="OpenID.Core">OpenID Connect Core 1.0</xref>, and
+	  the terms "Authorization Endpoint", "Authorization Server",
+	  "Client", "Client Authentication", "Client Identifier", "Client Secret",
+	  "Grant Type", "Protected Resource", "Redirection URI", "Refresh Token",
+	  and "Token Endpoint"
+	  defined by <xref target="RFC6749">OAuth 2.0</xref>.
+
         </t>
         <t>
           This specification also defines the following terms:
@@ -1241,7 +1247,7 @@
 	      <spanx style="verb">federation_historical_keys_endpoint</spanx>.
 	    </t>
 
-            <t hangText="endpoint_authentication_signing_alg_values_supported">
+            <t hangText="endpoint_auth_signing_alg_values_supported">
               <vspace/>
               OPTIONAL.
               JSON array containing a list of the supported
@@ -5067,18 +5073,16 @@ Host: trust-anchor.example.com
 	  <t>
 	    Like other OAuth and OpenID endpoints supporting client authentication,
 	    this specification defines metadata parameters saying which
-	    client authentication methods are supported.
+	    client authentication methods are supported for each endpoint.
 	    These largely parallel the
-	    <spanx style="verb">token_endpoint_auth_methods_supported</spanx> and
-	    <spanx style="verb">token_endpoint_auth_signing_alg_values_supported</spanx>
-	    metadata values defined in Section 3 of
+	    <spanx style="verb">token_endpoint_auth_methods_supported</spanx>
+	    metadata value defined in Section 3 of
 	    <xref target="OpenID.Discovery">OpenID Connect Discovery 1.0</xref>.
 	  </t>
 	  <t>
 	    Specifically, for each of the federation endpoints defined in
 	    <xref target="federation_entity"/>, parameters named
-	    <spanx style="verb">*_auth_methods</spanx> and
-	    <spanx style="verb">*_auth_signing_algs</spanx>
+	    <spanx style="verb">*_auth_methods</spanx>
 	    are defined, where the <spanx style="verb">*</spanx> represents the
 	    federation endpoint names
 	    <spanx style="verb">federation_fetch_endpoint</spanx>,
@@ -5087,8 +5091,10 @@ Host: trust-anchor.example.com
 	  </t>
 	  <t>
 	    The <spanx style="verb">*_auth_methods</spanx>
-	    metadata parameters list supported client authentication methods, just as
-	    <spanx style="verb">token_endpoint_auth_methods_supported</spanx> does.
+	    metadata parameters list supported client authentication methods
+	    for these endpoints, just as
+	    <spanx style="verb">token_endpoint_auth_methods_supported</spanx>
+	    does for the Token Endpoint.
 	    In addition, the value <spanx style="verb">none</spanx> MAY be used
 	    to indicate that client authentication is not required at the endpoint.
 	  </t>
@@ -5113,13 +5119,11 @@ Host: trust-anchor.example.com
 	    indicating that only unauthenticated requests are accepted.
 	  </t>
 	  <t>
-	    The <spanx style="verb">*_auth_signing_algs</spanx>
-	    metadata parameters list supported client authentication
-	    signing algorithms supported, just as
-	    <spanx style="verb">token_endpoint_auth_signing_alg_values_supported</spanx> does.
-	    If omitted and <spanx style="verb">private_key_jwt</spanx> is supported,
-	    the default value is <spanx style="verb">["RS256"]</spanx>.
-	    The value <spanx style="verb">none</spanx> MUST NOT be used.
+	    The <spanx style="verb">endpoint_auth_signing_alg_values_supported</spanx>
+	    metadata parameter lists supported client authentication
+	    signing algorithms supported for these endpoints, just as
+	    <spanx style="verb">token_endpoint_auth_signing_alg_values_supported</spanx>
+	    does for the Token Endpoint.
 	  </t>
 	</section>
 
@@ -5750,21 +5754,20 @@ Content-Type: application/json
             The Authentication Request is performed by passing a
             signed Request Object by value as described in Section 6.1 of
             <xref target="OpenID.Core">OpenID Connect Core 1.0</xref>
-            or using a pushed authorization request with a signed Request Object,
-	    as described in Section 3 of
+            or using a pushed authorization request, as described in
             <xref target="RFC9126">Pushed Authorization Requests</xref>.
 	  </t>
 	  <t>
-	    Authentication requests not using a signed Request Object
-	    MUST be rejected, since checking the request signature is used
-	    to validate that the Entity making the request controls the RP's keys.
+	    Authentication requests MUST demonstrate that the requesting Entity
+	    controls the Entity's RP keys, using one of the methods described below.
+	    Attempted authentication requests that do not do so MUST be rejected.
           </t>
 
           <section title="Using a Request Object Directly" anchor="UsingAuthzRequestObject">
 
             <t>
-              When a Request Object is used directly, the value of the
-              <spanx style="verb">request</spanx>
+              When a Request Object is used directly at the Authorization Endpoint,
+	      the value of the <spanx style="verb">request</spanx>
               parameter is a JWT whose Claims are the request parameters
               specified in Section 3.1.2 in
               <xref target="OpenID.Core">OpenID Connect Core 1.0</xref>.
@@ -5836,7 +5839,7 @@ Content-Type: application/json
               <t>
               Due to the large size of a Trust Chain, it may be necessary
               to use the HTTP POST method,
-              <spanx style="verb">request_uri</spanx>,
+              a <spanx style="verb">request_uri</spanx>,
               or
               a <xref target="RFC9126">Pushed Authorization Request</xref>
               for the request.
@@ -5892,21 +5895,22 @@ GET /authorize?
     &scope=openid+profile+email+address+phone
     &response_type=code
     &client_id=https%3A%2F%2Frp.example.com
-    &request=eyJhbGciOiJSUzI1NiIsImtpZCI6Ik5fX0Q5OEl2QjhOYWUta3dBNm5yT3QtaXBU
-        aGpIa0R4MzduaWNETUgzTjQifQ.eyJhdWQiOiJodHRwczovL29wLmV4YW1wbGUub
-        3JnL2F1dGhvcml6YXRpb24tZW5kcG9pbnQiLCJjbGllbnRfaWQiOiJodHRwczovL
-        3JwLmV4YW1wbGUuY29tIiwiZXhwIjoxNTg5Njk5MTYyLCJpYXQiOjE1ODk2OTkxM
-        DIsImlzcyI6Imh0dHBzOi8vcnAuZXhhbXBsZS5jb20iLCJqdGkiOiI0ZDNlYzBmO
-        DFmMTM0ZWU5YTk3ZTA0NDliZTZkMzJiZSIsIm5vbmNlIjoiNExYMG1GTXhkQmprR
-        210eDdhOFdJT25CIiwicmVkaXJlY3RfdXJpIjoiaHR0cHM6Ly9ycC5leGFtcGxlL
-        mNvbS9hdXRoel9jYiIsInJlc3BvbnNlX3R5cGUiOiJjb2RlIiwic2NvcGUiOiJvc
-        GVuaWQgcHJvZmlsZSBlbWFpbCBhZGRyZXNzIHBob25lIiwic3RhdGUiOiJZbVg4U
-        E05STdXYk5vTW5uaWVLS0JpcHRWVzBzUDJPWiIsInRydXN0X2NoYWluIjpbImV5S
-        mhiR2NpT2lKU1V6STFOaUlzSW10cFpDSTZJbXMxTkVoUmRFUnBZbmxIWTNNNVdsZ
-        FdUV1oyYVVobSAuLi4iLCJleUpoYkdjaU9pSlNVekkxTmlJc0ltdHBaQ0k2SWtKW
-        WRtWnliRzVvUVUxMVNGSXdOMkZxVlcxQlkwSlMgLi4uIiwiZXlKaGJHY2lPaUpTV
-        XpJMU5pSXNJbXRwWkNJNklrSllkbVp5Ykc1b1FVMTFTRkl3TjJGcVZXMUJZMEpTI
-        C4uLiJdfQ.Rv0isfuku0FcRFintgxgKDk7EnhFkpQRg3Tm6N6fCHAHEKFxVVdjy4
+    &request=eyJhbGciOiJSUzI1NiIsImtpZCI6Ik5fX0Q5OEl2QjhOYWUta3dBNm5yT3Q
+        taXBUaGpIa0R4MzduaWNETUgzTjQifQ.
+        eyJhdWQiOiJodHRwczovL29wLmV4YW1wbGUub3JnIiwiY2xpZW50X2lkIjoiaHR0
+        cHM6Ly9ycC5leGFtcGxlLmNvbSIsImV4cCI6MTU4OTY5OTE2MiwiaWF0IjoxNTg5
+        Njk5MTAyLCJpc3MiOiJodHRwczovL3JwLmV4YW1wbGUuY29tIiwianRpIjoiNGQz
+        ZWMwZjgxZjEzNGVlOWE5N2UwNDQ5YmU2ZDMyYmUiLCJub25jZSI6IjRMWDBtRk14
+        ZEJqa0dtdHg3YThXSU9uQiIsInJlZGlyZWN0X3VyaSI6Imh0dHBzOi8vcnAuZXhh
+        bXBsZS5jb20vYXV0aHpfY2IiLCJyZXNwb25zZV90eXBlIjoiY29kZSIsInNjb3Bl
+        Ijoib3BlbmlkIHByb2ZpbGUgZW1haWwgYWRkcmVzcyBwaG9uZSIsInN0YXRlIjoi
+        WW1YOFBNOUk3V2JOb01ubmllS0tCaXB0Vlcwc1AyT1oiLCJ0cnVzdF9jaGFpbiI6
+        WyJleUpoYkdjaU9pSlNVekkxTmlJc0ltdHBaQ0k2SW1zMU5FaFJkRVJwWW5sSFkz
+        TTVXbGRXVFdaMmFVaG0gLi4uIiwiZXlKaGJHY2lPaUpTVXpJMU5pSXNJbXRwWkNJ
+        NklrSllkbVp5Ykc1b1FVMTFTRkl3TjJGcVZXMUJZMEpTIC4uLiIsImV5SmhiR2Np
+        T2lKU1V6STFOaUlzSW10cFpDSTZJa0pZZG1aeWJHNW9RVTExU0ZJd04yRnFWVzFC
+        WTBKUyAuLi4iXX0.
+        Rv0isfuku0FcRFintgxgKDk7EnhFkpQRg3Tm6N6fCHAHEKFxVVdjy4
         9JboJtxKcQVZKN9TKn3lEYM1wtF1e9PQrNt4HZ21ICfnzxXuNx1F5SY1GXCU2n2y
         FVKtz3N0YkAFbTStzy-sPRTXB0stLBJH74RoPiLs2c6dDvrwEv__GA7oGkg2gWt6
         VDvnfDpnvFi3ZEUR1J8MOeW_VFsayrT9sNjyjsz62Po4LzvQKQMKxq0dNwPNYuuS
@@ -5983,21 +5987,21 @@ GET /authorize?
             <t>
               <xref target="RFC9126">Pushed Authorization Requests</xref>
               provide an
-              interoperable way to push an authorization request
+              interoperable way to push an authentication request parameters
               directly to the AS in exchange for a one-time-use
               <spanx style="verb">request_uri</spanx>.
 	      The standard PAR metadata parameters are used in the
 	      RP and OP metadata to indicate its use.
             </t>
 	    <t>
-	      When used with OpenID Federation,
-	      a Request Object MUST be sent to the PAR endpoint,
-	      signed with one of the RPs private keys.
-	      The corresponding public key MUST be in the RP's JWK Set.
-	      Furthermore, when used with OpenID Federation,
-	      the client authentication methods for the PAR endpoint
-	      are restricted to those proving possession of a private key.
-	      Likewise, the corresponding public key MUST be in the RP's JWK Set.
+	      When using PAR with Automatic Registration,
+	      either a Request Object MUST be used as a PAR parameter,
+	      with the Request Object being as described in
+	      <xref target="UsingAuthzRequestObject"/>, or
+	      a client authentication method for the PAR endpoint
+	      MUST be used that proves possession of one of the RP's private keys.
+	      Furthermore, the corresponding public key MUST be in the
+	      Entity's RP JWK Set.
 	    </t>
             <t>
               The two applicable PAR client authentication methods are:
@@ -6006,14 +6010,15 @@ GET /authorize?
 		  JWT Client authentication, as described
                   for <spanx style="verb">private_key_jwt</spanx> in Section 9 of
                   <xref target="OpenID.Core">OpenID Connect Core 1.0</xref>.
+		  In this case, the audience of the client authentication JWT
+		  MUST be the Entity Identifier of the OP's Entity.
                 </t>
                 <t>
                   mTLS using self-signed certificates,
 		  as described in Section 2.2 of <xref target="RFC8705"/>.
                   In this case, the self-signed certificate MUST be present as
                   the value of an <spanx style="verb">x5c</spanx>
-                  claim for one key in the JWK Set describing
-                  the RP's keys.
+                  claim for a key in the Entity's RP JWK Set.
 		  In this case, the server MUST omit certificate chain validation.
                 </t>
               </list>
@@ -6030,38 +6035,23 @@ POST /par HTTP/1.1
 Host: op.example.org
 Content-Type: application/x-www-form-urlencoded
 
-request=eyJhbGciOiJSUzI1NiIsImtpZCI6Ik5fX0Q5OEl2QjhOYWUta3dBNm5yT3QtaXBU
-        aGpIa0R4MzduaWNETUgzTjQifQ.eyJhdWQiOiJodHRwczovL29wLmV4YW1wbGUub
-        3JnL2F1dGhvcml6YXRpb24tZW5kcG9pbnQiLCJjbGllbnRfaWQiOiJodHRwczovL
-        3JwLmV4YW1wbGUuY29tIiwiZXhwIjoxNTg5Njk5MTYyLCJpYXQiOjE1ODk2OTkxM
-        DIsImlzcyI6Imh0dHBzOi8vcnAuZXhhbXBsZS5jb20iLCJqdGkiOiI0ZDNlYzBmO
-        DFmMTM0ZWU5YTk3ZTA0NDliZTZkMzJiZSIsIm5vbmNlIjoiNExYMG1GTXhkQmprR
-        210eDdhOFdJT25CIiwicmVkaXJlY3RfdXJpIjoiaHR0cHM6Ly9ycC5leGFtcGxlL
-        mNvbS9hdXRoel9jYiIsInJlc3BvbnNlX3R5cGUiOiJjb2RlIiwic2NvcGUiOiJvc
-        GVuaWQgcHJvZmlsZSBlbWFpbCBhZGRyZXNzIHBob25lIiwic3RhdGUiOiJZbVg4U
-        E05STdXYk5vTW5uaWVLS0JpcHRWVzBzUDJPWiIsInRydXN0X2NoYWluIjpbImV5S
-        mhiR2NpT2lKU1V6STFOaUlzSW10cFpDSTZJbXMxTkVoUmRFUnBZbmxIWTNNNVdsZ
-        FdUV1oyYVVobSAuLi4iLCJleUpoYkdjaU9pSlNVekkxTmlJc0ltdHBaQ0k2SWtKW
-        WRtWnliRzVvUVUxMVNGSXdOMkZxVlcxQlkwSlMgLi4uIiwiZXlKaGJHY2lPaUpTV
-        XpJMU5pSXNJbXRwWkNJNklrSllkbVp5Ykc1b1FVMTFTRkl3TjJGcVZXMUJZMEpTI
-        C4uLiJdfQ.Rv0isfuku0FcRFintgxgKDk7EnhFkpQRg3Tm6N6fCHAHEKFxVVdjy4
-        9JboJtxKcQVZKN9TKn3lEYM1wtF1e9PQrNt4HZ21ICfnzxXuNx1F5SY1GXCU2n2y
-        FVKtz3N0YkAFbTStzy-sPRTXB0stLBJH74RoPiLs2c6dDvrwEv__GA7oGkg2gWt6
-        VDvnfDpnvFi3ZEUR1J8MOeW_VFsayrT9sNjyjsz62Po4LzvQKQMKxq0dNwPNYuuS
-        fUmb-YvmFguxDb3weYl8WS-
-        48EIkP1h4b_KGU9x9n7a1fUOHrS02ATQZmaL8jUil7yLJqx5MiCsPr4pCAXV0doA
-        4pwhs_FIw
+redirect_uri=https%3A%2F%2Frp.example.com%2Fauthz_cb
+&scope=openid+profile+email+address+phone
+&response_type=code
+&nonce=4LX0mFMxdBjkGmtx7a8WIOnB
+&state=YmX8PM9I7WbNoMnnieKKBiptVW0sP2OZ
 &client_id=https%3A%2F%2Frp.example.com
 &client_assertion_type=urn%3Aietf%3Aparams%3Aoauth%3A
   client-assertion-type%3Ajwt-bearer
 &client_assertion=eyJhbGciOiJSUzI1NiIsImtpZCI6ImRVTjJ
   hMDF3Umtoa1NXcGxRVGh2Y1ZCSU5VSXdUVWRPVUZVMlRtVnJTbW
-  hFUVhnelpYbHBUemRRTkEifQ.eyJzdWIiOiAiaHR0cHM6Ly9ycC
-  5leGFtcGxlLmNvbSIsICJpc3MiOiAiaHR0cHM6Ly9ycC5leGFtc
-  GxlLmNvbSIsICJpYXQiOiAxNTg5NzA0NzAxLCAiZXhwIjogMTU4
-  OTcwNDc2MSwgImF1ZCI6ICJodHRwczovL29wLmV4YW1wbGUub3J
-  nL2F1dGhvcml6YXRpb24iLCAianRpIjogIjM5ZDVhZTU1MmQ5Yz
-  Q4ZjBiOTEyZGM1NTY4ZWQ1MGQ2In0.oUt9Knx_lxb4V2S0tyNFH
+  hFUVhnelpYbHBUemRRTkEifQ.
+  eyJzdWIiOiAiaHR0cHM6Ly9ycC5leGFtcGxlLmNvbSIsICJpc3M
+  iOiAiaHR0cHM6Ly9ycC5leGFtcGxlLmNvbSIsICJpYXQiOiAxNT
+  g5NzA0NzAxLCAiZXhwIjogMTU4OTcwNDc2MSwgImF1ZCI6ICJod
+  HRwczovL29wLmV4YW1wbGUub3JnIiwgImp0aSI6ICIzOWQ1YWU1
+  NTJkOWM0OGYwYjkxMmRjNTU2OGVkNTBkNiJ9.
+  oUt9Knx_lxb4V2S0tyNFH
   CNZeP7sImBy5XDsFxv1cUpGkAojNXSy2dnU5HEzscMgNW4wguz6
   KDkC01aq5OfN04SuVItS66bsx0h4Gs7grKAp_51bClzreBVzU4g
   _-dFTgF15T9VLIgM_juFNPA_g4Lx7Eb5r37rWTUrzXdmfxeou0X
@@ -8402,7 +8392,7 @@ HTTP/1.1 302 Found
 	</front>
       </reference>
 
-      <xi:include href="https://bib.ietf.org/public/rfc/bibxml3/reference.I-D.draft-ietf-oauth-resource-metadata-12.xml" />
+      <xi:include href="https://bib.ietf.org/public/rfc/bibxml3/reference.I-D.draft-ietf-oauth-resource-metadata-13.xml" />
 
     </references>
 
@@ -9761,6 +9751,16 @@ Host: op.umu.se
 	    Fixed #98: Required audience when using
 	    <spanx style="verb">private_key_jwt</spanx> with PAR
 	    to be the Authorization Server's Entity Identifier.
+	  </t>
+	  <t>
+	    Reverted change to allow PAR requests not using Request Objects
+	    when the client authentication method uses a signature with
+	    with a Federation Entity Key.
+	  </t>
+	  <t>
+	    Fixed #104: Removed the <spanx style="verb">*_auth_signing_algs</spanx>
+	    metadata parameters in favor of
+	    <spanx style="verb">endpoint_auth_signing_alg_values_supported</spanx>.
 	  </t>
 	</list>
       </t>

--- a/openid-federation-1_0.xml
+++ b/openid-federation-1_0.xml
@@ -1378,77 +1378,43 @@
               Registration as described in <xref target="explicit"/>,
               then this claim is REQUIRED.
             </t>
-            <t hangText="request_authentication_methods_supported">
+
+            <t hangText="pushed_authentication_methods_supported">
               <vspace/>
               OPTIONAL.
-	      An OP MUST be able to verify that a request comes from an RP
-	      that is a member of a federation that the OP is a member of.
-	      This is done via request authentication methods.
-	      These methods achieve this by proving that
-	      the RP is in possession of a key that appears in its metadata.
-	      This parameter declares the request authentication methods that the OP supports.
-	      <vspace blankLine="1"/>
-
-	      The <spanx style="verb">request_authentication_methods_supported</spanx>
-	      value is a JSON object where the member names are names of endpoints
-	      where the request authentication occurs.
-	      This MAY be either at
-	      the OP's Authorization Endpoint or
-	      the OP's Pushed Authorization Request (PAR) endpoint.
-	      Supported endpoint identifiers are
-	      <spanx style="verb">authorization_endpoint</spanx> and
-	      <spanx style="verb">pushed_authorization_request_endpoint</spanx>.
-	      The values of the JSON object members for the endpoint names are
-	      JSON arrays containing the names of the request authentication methods
-	      used at those endpoints.
-	      <vspace blankLine="1"/>
-
+	      A Pushed Authorization Request (PAR) <xref target="RFC9126"/>
+	      can be used with Automatic Registration,
+	      as described in <xref target="authn-request"/>.
 	      Some OAuth 2.0 client authentication methods can be used at the
 	      <spanx style="verb">pushed_authorization_request_endpoint</spanx>
 	      to achieve request authentication.
 	      They are the subset of those listed in the
 	      IANA "OAuth Token Endpoint Authentication Methods" registry <xref target="IANA.OAuth.Parameters"/>
 	      that perform client authentication by proving possession of a private key.
-              These client authentication methods are:
+	      The <spanx style="verb">pushed_authentication_methods_supported</spanx>
+	      metadata value lists the client authentication methods
+	      supported by the OP that can be used in this manner.
+	      Its value is a JSON array of supported client authentication methods.
+	      Values that MAY be used are:
               <list style="hanging">
                 <t hangText="private_key_jwt">
                   <vspace/>
                   This client authentication method is described in Section 9 of
                   <xref target="OpenID.Core">OpenID Connect Core 1.0</xref>.
-                  Note that if <spanx style="verb">private_key_jwt</spanx> is
-                  used, the audience of the signed JWT MUST be either the URL of
-                  the Authorization Server's Authorization Endpoint or the
-                  Authorization Server's Entity Identifier.
-                </t>
-                <t hangText="tls_client_auth">
-                  <vspace/>
-                  Section 2.1 of
-                  <xref target="RFC8705"/>.
+                  When <spanx style="verb">private_key_jwt</spanx> is used,
+		  the audience of the signed JWT MUST be
+                  the Authorization Server's Entity Identifier.
                 </t>
                 <t hangText="self_signed_tls_client_auth">
                   <vspace/>
-                  Section 2.2 of
+                  This client authentication method is described in Section 2.2 of
                   <xref target="RFC8705"/>.
                 </t>
               </list>
-              <vspace blankLine="1"/>
-
-              A request authentication method that is not a client authentication method is:
-              <list style="hanging">
-                <t hangText="request_object">
-                  <vspace/>
-                  Use of a Request Object, as described in
-                  <xref target="OpenID.Core">OpenID Connect Core 1.0</xref>.
-		  The request authentication is performed by verifying that
-		  the request object is signed with a key that the RP controls.
-		  Use of Request Objects by Automatic Registration is described in
-                  <xref target="automatic"/>.
-                </t>
-              </list>
-	      The <spanx style="verb">request_object</spanx> method MAY be used at either endpoint.
-              <vspace blankLine="1"/>
-
-	      Additional request authentication methods MAY be defined and used.
+	      <vspace blankLine="1"/>
+	      In both cases, the signing key MUST be one of the keys
+	      in the RP's JWK Set published in its metadata.
+	      Additional pushed authentication methods MAY be defined and used.
 	    </t>
 
             <t hangText="request_authentication_signing_alg_values_supported">
@@ -1461,8 +1427,6 @@
               used in the Request Object
               contained in the request parameter of an authorization request or
               in the <spanx style="verb">private_key_jwt</spanx> of a pushed authorization request.
-              This entry MUST be present if either of these authentication methods are specified
-              in the <spanx style="verb">request_authentication_methods_supported</spanx> entry.
               No default algorithms are implied if this entry is omitted.
               Servers SHOULD support <spanx style="verb">RS256</spanx>.
               The value <spanx style="verb">none</spanx> MUST NOT be used.
@@ -1521,17 +1485,10 @@
             "private_key_jwt"
          ],
          "pushed_authorization_request_endpoint":"https://op.umu.se/openid/par",
-         "request_authentication_methods_supported": {
-            "authorization_endpoint": [
-                "request_object"
-            ],
-            "pushed_authorization_request_endpoint": [
-                "request_object",
-                "private_key_jwt",
-                "tls_client_auth",
-                "self_signed_tls_client_auth"
-            ]
-         },
+         "pushed_authentication_methods_supported": {
+            "private_key_jwt",
+            "self_signed_tls_client_auth"
+         ],
          "request_authentication_signing_alg_values_supported": [
             "ES256",
             "RS256"
@@ -5793,11 +5750,6 @@ Content-Type: application/json
               Instead, the Automatic Registration model requires the RP to use
               asymmetric cryptography to authenticate its requests.
             </t>
-            <t>
-              The OP MUST publish that it supports one or more request authentication
-              methods using the <spanx style="verb">openid_provider</spanx> metadata parameter
-              <spanx style="verb">request_authentication_methods_supported</spanx>.
-            </t>
           </list>
         </t>
         <t>
@@ -7213,11 +7165,11 @@ HTTP/1.1 302 Found
           <t>
             <list style='symbols'>
               <t>
-                Metadata Name: <spanx style="verb">request_authentication_methods_supported</spanx>
+                Metadata Name: <spanx style="verb">pushed_authentication_methods_supported</spanx>
               </t>
               <t>
                 Metadata Description:
-                Authentication request authentication methods supported
+                Pushed authentication methods supported
               </t>
               <t>
                 Change Controller: OpenID Foundation Artifact Binding Working Group - openid-specs-ab@lists.openid.net
@@ -9825,7 +9777,13 @@ Host: op.umu.se
 	-40
 	<list style="symbols">
 	  <t>
-	    TBD
+	    Fixed #34:
+	    Replaced <spanx style="verb">request_authentication_methods_supported</spanx>
+	    with <spanx style="verb">pushed_authentication_methods_supported</spanx>.
+	  </t>
+	  <t>
+	    Fixed #98: Required audience when using <spanx style="verb">private_key_jwt</spanx>
+	    to be the Authorization Server's Entity Identifier.
 	  </t>
 	</list>
       </t>


### PR DESCRIPTION
Fixes #34 
Replaces `request_authentication_methods_supported` with `pushed_authentication_methods_supported`.  This simplifies things by eliminating the `request_object` request authentication method, since signed requests are always required.  The PR also removes `tls_client_auth` from the supported request authentication methods.

Fixes #98 
Requires the audience when using `private_key_jwt` to be the Authorization Server's Entity Identifier.