### PR TITLE
clarify merging of essential policy operators

### DIFF
--- a/openid-federation-1_0.xml
+++ b/openid-federation-1_0.xml
@@ -2494,17 +2494,9 @@
                 Order of application: Last
               </t>
               <t>
-                Operator value merge: If a Superior has specified
-                <spanx style="verb">essential=true</spanx>, then a Subordinate
-                MUST NOT change that. If a Superior has specified
-                <spanx style="verb">essential=false</spanx>, then a Subordinate
-                is allowed to change that to
-                <spanx style="verb">essential=true</spanx>. If a Superior has
-                not specified <spanx style="verb">essential</spanx>, then a
-                Subordinate can set <spanx style="verb">essential</spanx> to
-                <spanx style="verb">true</spanx> or
-                <spanx style="verb">false</spanx>. If those conditions are not
-                met, this MUST result in a policy error.
+                Operator value merge: The result of merging the values of two 
+                <spanx style="verb">essential</spanx> operators is the logical 
+                disjunction (<spanx style="verb">OR</spanx>) of the operator values.
               </t>
             </section>
 


### PR DESCRIPTION
As noted in my issue #11 I think the current phrasing on merging the `essential` policy operator is not clear enough.

This is my proposal on how to simplify the phrasing, as I think the semantic should be. 