### PR TITLE
Policy operators: more permissive restrictions when combining add and superset_of

### DIFF
--- a/openid-federation-1_0.xml
+++ b/openid-federation-1_0.xml
@@ -2177,10 +2177,7 @@
                     <spanx style="verb">subset_of</spanx>.
                   </t>
                   <t>
-                    MAY be combined with <spanx style="verb">superset_of</spanx>,
-                    in which case the values of <spanx style="verb">add</spanx>
-                    MUST be a superset of the values of
-                    <spanx style="verb">superset_of</spanx>.
+                    MAY be combined with <spanx style="verb">superset_of</spanx>.
                   </t>
                   <t>
                     MAY be combined with <spanx style="verb">essential</spanx>.
@@ -2421,10 +2418,7 @@
                 Combination with other operators in a metadata parameter policy:
                 <list style="symbols">
                   <t>
-                    MAY be combined with <spanx style="verb">add</spanx>, in
-                    which case the values of <spanx style="verb">add</spanx>
-                    MUST be a superset of the values of
-                    <spanx style="verb">superset_of</spanx>.
+                    MAY be combined with <spanx style="verb">add</spanx>.
                   </t>
                   <t>
                     MAY be combined with <spanx style="verb">default</spanx>, in

--- a/openid-federation-1_0.xml
+++ b/openid-federation-1_0.xml
@@ -2177,7 +2177,11 @@
                     <spanx style="verb">subset_of</spanx>.
                   </t>
                   <t>
-                    MAY be combined with <spanx style="verb">superset_of</spanx>.
+                    MAY be combined with <spanx style="verb">superset_of</spanx>,
+                    in which case the result of applying the
+                    <spanx style="verb">add</spanx> operator
+                    MUST be a superset of the values of
+                    <spanx style="verb">superset_of</spanx>.
                   </t>
                   <t>
                     MAY be combined with <spanx style="verb">essential</spanx>.
@@ -2418,7 +2422,11 @@
                 Combination with other operators in a metadata parameter policy:
                 <list style="symbols">
                   <t>
-                    MAY be combined with <spanx style="verb">add</spanx>.
+                    MAY be combined with <spanx style="verb">add</spanx>, in
+                    which case the result of applying the
+                    <spanx style="verb">add</spanx> operator
+                    MUST be a superset of the values of
+                    <spanx style="verb">superset_of</spanx>.
                   </t>
                   <t>
                     MAY be combined with <spanx style="verb">default</spanx>, in


### PR DESCRIPTION
As noted in #11 I'd argue that the `add` and `superset_of` policy operators can be combined nevertheless of their value.
`add` is applied first, then `superset_of` checks if the value is a superset.