### PR TITLE
Policy Operators: allow combiniation of value with other operators if values dont conflict

### DIFF
--- a/openid-federation-1_0.xml
+++ b/openid-federation-1_0.xml
@@ -2118,6 +2118,34 @@
                 Combination with other operators in a metadata parameter policy:
                 <list style="symbols">
                   <t>
+                    MAY be combined with <spanx style="verb">add</spanx>,
+                    in which case the values of <spanx style="verb">add</spanx>
+                    MUST be a subset of the values of
+                    <spanx style="verb">value</spanx>.
+                  </t>
+                  <t>
+                    MAY be combined with <spanx style="verb">default</spanx>,
+                    in which case the value of <spanx style="verb">default</spanx>
+                    is ignored.
+                  </t>
+                  <t>
+                    MAY be combined with <spanx style="verb">one_of</spanx>,
+                    in which case the <spanx style="verb">value</spanx> value
+                    MUST be among the <spanx style="verb">one_of</spanx> values.
+                  </t>
+                  <t>
+                    MAY be combined with <spanx style="verb">subset_of</spanx>,
+                    in which case the values of <spanx style="verb">value</spanx>
+                    MUST be a subset of the values of
+                    <spanx style="verb">subset_of</spanx>.
+                  </t>
+                  <t>
+                    MAY be combined with <spanx style="verb">superset_of</spanx>,
+                    in which case the values of <spanx style="verb">value</spanx>
+                    MUST be a superset of the values of
+                    <spanx style="verb">superset_of</spanx>.
+                  </t>
+                  <t>
                     MAY be combined with <spanx style="verb">essential</spanx>.
                   </t>
                 </list>
@@ -2167,6 +2195,9 @@
               <t>
                 Combination with other operators in a metadata parameter policy:
                 <list style="symbols">
+                  <t>
+                    MAY be combined with <spanx style="verb">value</spanx>.
+                  </t>
                   <t>
                     MAY be combined with <spanx style="verb">default</spanx>.
                   </t>
@@ -2225,6 +2256,12 @@
               <t>
                 Combination with other operators in a metadata parameter policy:
                 <list style="symbols">
+                  <t>
+                    MAY be combined with <spanx style="verb">value</spanx>,
+                    in which case the values of <spanx style="verb">add</spanx>
+                    MUST be a subset of the values of
+                    <spanx style="verb">value</spanx>.
+                  </t>
                   <t>
                     MAY be combined with <spanx style="verb">add</spanx>.
                   </t>
@@ -2293,6 +2330,11 @@
                 Combination with other operators in a metadata parameter policy:
                 <list style="symbols">
                   <t>
+                    MAY be combined with <spanx style="verb">value</spanx>,
+                    in which case the value of <spanx style="verb">value</spanx>
+                    MUST be among the <spanx style="verb">one_of</spanx> values.
+                  </t>
+                  <t>
                     MAY be combined with <spanx style="verb">default</spanx>,
                     in which case the value of default MUST be among the
                     <spanx style="verb">one_of</spanx> values.
@@ -2352,6 +2394,12 @@
               <t>
                 Combination with other operators in a metadata parameter policy:
                 <list style="symbols">
+                  <t>
+                    MAY be combined with <spanx style="verb">value</spanx>,
+                    in which case the values of <spanx style="verb">value</spanx>
+                    MUST be a subset of the values of
+                    <spanx style="verb">subset_of</spanx>.
+                  </t>
                   <t>
                     MAY be combined with <spanx style="verb">add</spanx>, in
                     which case the values of <spanx style="verb">add</spanx>
@@ -2420,6 +2468,12 @@
               <t>
                 Combination with other operators in a metadata parameter policy:
                 <list style="symbols">
+                  <t>
+                    MAY be combined with <spanx style="verb">value</spanx>,
+                    in which case the values of <spanx style="verb">value</spanx>
+                    MUST be a superset of the values of
+                    <spanx style="verb">superset_of</spanx>.
+                  </t>
                   <t>
                     MAY be combined with <spanx style="verb">add</spanx>, in
                     which case the values of <spanx style="verb">add</spanx>


### PR DESCRIPTION
This PR is related to #11 

While this might need more discussion, I think the `value` policy operator can be combined with other policy operators (originating from other intermediates), if they don't conflict.