### PR TITLE
Restore trust mark status iat query parameter

### DIFF
--- a/openid-federation-1_0.xml
+++ b/openid-federation-1_0.xml
@@ -4407,6 +4407,17 @@ Host: openid.sunet.se
                 <vspace/>
                 REQUIRED. Identifier of the Trust Mark.
               </t>
+              <t hangText="iat">
+                <vspace/>
+                OPTIONAL. Number. Time when this Trust Mark was issued.
+                This is expressed as Seconds Since the Epoch, as defined in
+                <xref target="RFC7519"/>. If
+                <spanx style="verb">iat</spanx> is not specified and the
+                Trust Mark issuer has issued several Trust Marks with the
+                identifier specified in the request to the
+                Entity identified by <spanx style="verb">sub</spanx>, the
+                most recent one is assumed.
+              </t>
             </list>
           </t>
 	  <t>


### PR DESCRIPTION
#109 was merged without noticing that @rohe had objected to removing `iat` in his comment https://github.com/openid/federation/issues/24#issuecomment-2404347034.  Given that `iat` was removed without consensus to do so, I plan to merge this to restore it at the end of next week unless @rohe drops his objection to its removal, given that having the `iat` query parameter was the status quo.

@zachmann 
