### PR TITLE
Define application/explicit-registration-response+jwt media type

### DIFF
--- a/openid-federation-1_0.xml
+++ b/openid-federation-1_0.xml
@@ -24,7 +24,7 @@
 
   <front>
     <title abbrev="OpenID Federation">OpenID Federation 1.0 -
-      draft 40
+      draft 41
     </title>
 
     <author fullname="Roland Hedberg" initials="R." role="editor"
@@ -87,7 +87,7 @@
       </address>
     </author>
 
-    <date day="24" month="October" year="2024"/>
+    <date day="28" month="October" year="2024"/>
 
     <workgroup>OpenID Connect Working Group</workgroup>
 
@@ -6580,7 +6580,13 @@ HTTP/1.1 302 Found
               <t>
                 A successful response MUST have an HTTP status code 200 and
                 the content type
-                <spanx style="verb">application/entity-statement+jwt</spanx>.
+                <spanx style="verb">application/explicit-registration-response+jwt</spanx>.
+		Furthermore, the <spanx style="verb">typ</spanx> header parameter
+		value in the response MUST be
+		<spanx style="verb">explicit-registration-response+jwt</spanx>
+		(and not <spanx style="verb">entity-statement+jwt</spanx>)
+		to prevent confusion between the Explicit Registration response
+		and normal Entity Statements.
               </t>
               <t>
                 For a client registration error, the response is as defined in
@@ -7006,6 +7012,16 @@ HTTP/1.1 302 Found
 	  The <spanx style="verb">application/jwk-set+jwt</spanx>
 	  media type is used to specify that the associated content is
 	  a signed JWK Set, as defined in <xref target="HistKeysResp"/>.
+	  No parameters are used with this media type.
+	</t>
+      </section>
+
+      <section anchor="explicit-registration-response+jwt"
+	       title='"application/explicit-registration-response+jwt" Media Type'>
+	<t>
+	  The <spanx style="verb">application/explicit-registration-response+jwt</spanx>
+	  media type is used to specify that the associated content is
+	  an Explicit Registration response, as defined in <xref target="cliregresp"/>.
 	  No parameters are used with this media type.
 	</t>
       </section>
@@ -7789,7 +7805,76 @@ HTTP/1.1 302 Found
             <?rfc subcompact="no"?>
           </t>
 
+          <t>
+            <?rfc subcompact="yes"?>
+            <list style="symbols">
+              <t>
+                Type name: application
+              </t>
+              <t>
+                Subtype name: explicit-registration-response+jwt
+              </t>
+              <t>
+                Required parameters: n/a
+              </t>
+              <t>
+                Optional parameters: n/a
+              </t>
+              <t>
+                Encoding considerations: binary;
+                An Explicit Registration response is a JWT;
+                JWT values are encoded as a
+                series of base64url-encoded values (some of which may be the
+                empty string) separated by period ('.') characters.
+              </t>
+              <t>
+                Security considerations: See <xref target="Security"/> of this specification
+              </t>
+              <t>
+                Interoperability considerations: n/a
+              </t>
+              <t>
+                Published specification: <xref target="explicit-registration-response+jwt"/> of this specification
+              </t>
+              <t>
+                Applications that use this media type:
+                Applications that use this specification
+              </t>
+              <t>
+                Fragment identifier considerations: n/a
+              </t>
+              <t>
+                Additional information:<list style="empty">
+                <t>Magic number(s): n/a</t>
+                <t>File extension(s): n/a</t>
+                <t>Macintosh file type code(s): n/a </t></list>
+                <vspace/>
+              </t>
+              <t>
+                Person &amp; email address to contact for further information:
+                <vspace/>
+                Michael B. Jones, michael_b_jones@hotmail.com
+              </t>
+              <t>
+                Intended usage: COMMON
+              </t>
+              <t>
+                Restrictions on usage: none
+              </t>
+              <t>
+                Author: Michael B. Jones, michael_b_jones@hotmail.com
+              </t>
+              <t>
+                Change controller: OpenID Foundation Artifact Binding Working Group - openid-specs-ab@lists.openid.net
+              </t>
+              <t>
+                Provisional registration? No
+              </t>
+            </list>
+            <?rfc subcompact="no"?>
+          </t>
         </section>
+
       </section>
 
       <section anchor="ParameterRegistry" title="OAuth Parameters Registration">
@@ -9707,6 +9792,17 @@ Host: op.umu.se
 
     <section anchor="History" title="Document History">
       <t>[[ To be removed from the final specification ]]</t>
+
+      <t>
+	-41
+	<list style="symbols">
+	  <t>
+	    Define media type for Explicit Registration responses
+	    <spanx style="verb">application/explicit-registration-response+jwt</spanx>
+	    distinct from <spanx style="verb">application/entity-statement+jwt</spanx>.
+	  </t>
+	</list>
+      </t>
 
       <t>
 	-40


### PR DESCRIPTION
to prevent confusion between Explicit Registration responses and normal Entity Statements.