### PR TITLE
Make Seconds Since the Epoch language consistent

### DIFF
--- a/openid-federation-1_0.xml
+++ b/openid-federation-1_0.xml
@@ -513,7 +513,7 @@
             <t hangText="iat">
               <vspace/>
               REQUIRED. Number. Time when this statement was issued.
-                This is expressed as Seconds Since the Epoch, as defined in
+                This is expressed as Seconds Since the Epoch, per
                 <xref target="RFC7519"/>.
             </t>
             <t hangText="exp">
@@ -521,7 +521,7 @@
               REQUIRED. Number.
               Expiration time after which the statement MUST NOT be
               accepted for processing. This is expressed as Seconds
-              Since the Epoch, as defined in <xref target="RFC7519"/>.
+              Since the Epoch, per <xref target="RFC7519"/>.
             </t>
             <t hangText="jwks">
               <vspace/>
@@ -1073,7 +1073,7 @@
           <spanx style="verb">trust_chain</spanx> JWS header parameter,
           with a few exceptions.
           Entity Configurations and Subordinate Statements MUST NOT
-          contain the <spanx style="verb">trust_chain</spanx>  header parameter,
+          contain the <spanx style="verb">trust_chain</spanx> header parameter,
           as they are integral components of a Trust Chain. Additionally,
           the Authorization Signed Request Object SHOULD NOT contain the
           <spanx style="verb">trust_chain</spanx> header parameter, because
@@ -1614,14 +1614,14 @@
 		  <t hangText="iat">
 		    <vspace/>
 		    OPTIONAL. Number. Time when this signed JWK Set was issued.
-        This is expressed as Seconds Since the Epoch, as defined in
+        This is expressed as Seconds Since the Epoch, per
         <xref target="RFC7519"/>.
 		  </t>
 		  <t hangText="exp">
 		    <vspace/>
 		    OPTIONAL. Number. This claim identifies the time when the JWT is
 		    no longer valid. This is expressed as Seconds
-        Since the Epoch, as defined in <xref target="RFC7519"/>.
+        Since the Epoch, per <xref target="RFC7519"/>.
 		  </t>
 		</list>
 		More claims are defined in <xref target="RFC7519"/>; of
@@ -3278,7 +3278,7 @@
               <t hangText="iat">
                 <vspace/>
                 REQUIRED. Number. Time when this Trust Mark was issued.
-                This is expressed as Seconds Since the Epoch, as defined in
+                This is expressed as Seconds Since the Epoch, per
                 <xref target="RFC7519"/>.
               </t>
               <t hangText="logo_uri">
@@ -3386,7 +3386,7 @@
               <t hangText="iat">
                 <vspace/>
                 REQUIRED. Number. Time when this delegation was issued.
-                This is expressed as Seconds Since the Epoch, as defined in
+                This is expressed as Seconds Since the Epoch, per
                 <xref target="RFC7519"/>.
               </t>
               <t hangText="exp">
@@ -4248,13 +4248,13 @@ Host: openid.sunet.se
               <t hangText="iat">
                 <vspace/>
                 REQUIRED. Number. Time when this resolution was issued.
-                This is expressed as Seconds Since the Epoch, as defined in
+                This is expressed as Seconds Since the Epoch, per
                 <xref target="RFC7519"/>.
               </t>
               <t hangText="exp">
                 <vspace/>
                 REQUIRED. Number. Time when this resolution is no longer valid.
-                This is expressed as Seconds Since the Epoch, as defined in <xref target="RFC7519"/>.
+                This is expressed as Seconds Since the Epoch, per <xref target="RFC7519"/>.
                 It MUST correspond to the <spanx style="verb">exp</spanx> value of
                 the Trust Chain from which the resolve response was derived.
               </t>
@@ -4418,7 +4418,7 @@ Host: openid.sunet.se
               <t hangText="iat">
                 <vspace/>
                 OPTIONAL. Number. Time when this Trust Mark was issued.
-                This is expressed as Seconds Since the Epoch, as defined in
+                This is expressed as Seconds Since the Epoch, per
                 <xref target="RFC7519"/>. If
                 <spanx style="verb">iat</spanx> is not specified and the
                 Trust Mark issuer has issued several Trust Marks with the
@@ -4773,7 +4773,7 @@ Host: trust-anchor.example.com
               <t hangText="iat">
                 <vspace/>
                 REQUIRED. Number. Time when this historical keys JWT was issued.
-                This is expressed as Seconds Since the Epoch, as defined in
+                This is expressed as Seconds Since the Epoch, per
                 <xref target="RFC7519"/>.
               </t>
               <t hangText="keys">
@@ -4798,13 +4798,13 @@ Host: trust-anchor.example.com
                     <t hangText="iat">
                       <vspace/>
                       OPTIONAL. Number. Time when this key was issued.
-                      This is expressed as Seconds Since the Epoch, as defined in
+                      This is expressed as Seconds Since the Epoch, per
                       <xref target="RFC7519"/>.
                     </t>
                     <t hangText="exp">
                       <vspace/>
                       REQUIRED. Number. Expiration time for the key.
-                      This is expressed as Seconds Since the Epoch, as defined in
+                      This is expressed as Seconds Since the Epoch, per
                       <xref target="RFC7519"/>,
                       After this time the key MUST NOT be considered valid.
                     </t>
@@ -5799,12 +5799,12 @@ Content-Type: application/json
                   <vspace/>
                   REQUIRED. Number. Expiration time after which the JWT MUST
                   NOT be accepted for processing. This is expressed as Seconds
-                  Since the Epoch, as defined in <xref target="RFC7519"/>.
+                  Since the Epoch, per <xref target="RFC7519"/>.
                 </t>
                 <t hangText="iat">
                   <vspace/>
                   OPTIONAL. Number. Time when this Request Object was issued.
-                  This is expressed as Seconds Since the Epoch, as defined in
+                  This is expressed as Seconds Since the Epoch, per
                   <xref target="RFC7519"/>.
                 </t>
                 <t hangText="trust_chain" anchor="trust_chain_param">
@@ -8539,7 +8539,7 @@ HTTP/1.1 302 Found
         </front>
       </reference>
 
-      <reference anchor="IANA.JOSE" target="https://www.iana.org/assignments/jose/">
+      <reference anchor="IANA.JOSE" target="https://www.iana.org/assignments/jose">
         <front>
           <title>JSON Object Signing and Encryption (JOSE)</title>
           <author>


### PR DESCRIPTION
Sometimes we say "Seconds Since the Epoch, as defined in".
Sometimes we say "Seconds Since the Epoch, per".
This PR uses the second, more concise form, in all cases.