### PR TITLE
Define additional error codes

### DIFF
--- a/openid-federation-1_0.xml
+++ b/openid-federation-1_0.xml
@@ -6180,7 +6180,8 @@ redirect_uri=https%3A%2F%2Frp.example.com%2Fauthz_cb
 	    as a component of an open redirector.
 	  </t>
 	  <t>
-	    If the OP fails to establish trust with the RP,
+	    If the OP fails to establish trust with the RP or
+	    finds the RP metadata to be invalid or in conflict with metadata policy,
 	    it MUST treat the redirection URI as invalid
 	    and not perform redirection.
 	    This means that the error codes

--- a/openid-federation-1_0.xml
+++ b/openid-federation-1_0.xml
@@ -87,7 +87,7 @@
       </address>
     </author>
 
-    <date day="19" month="November" year="2024"/>
+    <date day="26" month="November" year="2024"/>
 
     <workgroup>OpenID Connect Working Group</workgroup>
 
@@ -5173,10 +5173,9 @@ Host: trust-anchor.example.com
 		  The Trust Anchor cannot be found or used.
 		  The HTTP response status code SHOULD be 404 (Not Found).
 		</t>
-		<t hangText="invalid_trust_chain">
+		<t hangText="trust_chain_validation_failed">
 		  <vspace/>
-		  A Trust Chain cannot be constructed or used.
-		  The HTTP response status code SHOULD be 404 (Not Found).
+		  The HTTP response status code SHOULD be 400 (Bad Request).
 		</t>
 		<t hangText="invalid_metadata">
 		  <vspace/>
@@ -6170,7 +6169,9 @@ redirect_uri=https%3A%2F%2Frp.example.com%2Fauthz_cb
 	    If the OP fails to establish trust with the RP,
 	    it MUST treat the redirection URI as invalid
 	    and not perform redirection.
-	    This means that the two error codes defined below,
+	    This means that the error codes
+	    <spanx style="verb">invalid_trust_anchor</spanx> and
+	    <spanx style="verb">trust_chain_validation_failed</spanx>
 	    both of which are about reasons trust failed to be established,
 	    SHOULD only be returned in
 	    <xref target="RFC9126">Pushed Authorization Request</xref>
@@ -6179,20 +6180,9 @@ redirect_uri=https%3A%2F%2Frp.example.com%2Fauthz_cb
           <t>
             In addition to the error codes contained in the
 	    IANA "OAuth Extensions Error Registry" registry <xref target="IANA.OAuth.Parameters"/>,
-	    this specification also defines the following error
-            codes:
-          </t>
-          <t>
-            <list style="hanging">
-              <t hangText="missing_trust_anchor">
-                <vspace/>
-                No trusted Trust Anchor could be found.
-              </t>
-              <t hangText="trust_chain_validation_failed">
-                <vspace/>
-                Trust chain validation failed.
-              </t>
-            </list>
+	    this specification also defines the error codes
+	    in <xref target="error_response"/>,
+	    which MAY also be used.
           </t>
           <figure>
             <preamble>

--- a/openid-federation-1_0.xml
+++ b/openid-federation-1_0.xml
@@ -5183,7 +5183,7 @@ Host: trust-anchor.example.com
 		  The Trust Anchor cannot be found or used.
 		  The HTTP response status code SHOULD be 404 (Not Found).
 		</t>
-		<t hangText="trust_chain_validation_failed">
+		<t hangText="invalid_trust_chain">
 		  <vspace/>
 		  The Trust Chain cannot be validated.
 		  The HTTP response status code SHOULD be 400 (Bad Request).
@@ -5215,6 +5215,7 @@ Host: trust-anchor.example.com
                 <t hangText="unsupported_parameter">
                   <vspace/>
                   The server does not support the requested parameter.
+                  The HTTP response status code SHOULD be 400 (Bad Request).
                 </t>
               </list>
             </t>
@@ -6181,7 +6182,7 @@ redirect_uri=https%3A%2F%2Frp.example.com%2Fauthz_cb
 	    and not perform redirection.
 	    This means that the error codes
 	    <spanx style="verb">invalid_trust_anchor</spanx> and
-	    <spanx style="verb">trust_chain_validation_failed</spanx>
+	    <spanx style="verb">invalid_trust_chain</spanx>
 	    both of which are about reasons trust failed to be established,
 	    SHOULD only be returned in
 	    <xref target="RFC9126">Pushed Authorization Request</xref>
@@ -7435,6 +7436,50 @@ HTTP/1.1 302 Found
           <t>
             <?rfc subcompact="yes"?>
             <list style="symbols">
+              <t>Name: invalid_request</t>
+              <t>Usage Location: authorization endpoint</t>
+              <t>Protocol Extension: OpenID Federation</t>
+              <t>
+                Change Controller: OpenID Foundation Artifact Binding Working Group - openid-specs-ab@lists.openid.net
+              </t>
+              <t>Reference: <xref target="error_response"/> of this specification</t>
+            </list>
+          </t>
+          <t>
+            <list style="symbols">
+              <t>Name: invalid_client</t>
+              <t>Usage Location: authorization endpoint</t>
+              <t>Protocol Extension: OpenID Federation</t>
+              <t>
+                Change Controller: OpenID Foundation Artifact Binding Working Group - openid-specs-ab@lists.openid.net
+              </t>
+              <t>Reference: <xref target="error_response"/> of this specification</t>
+            </list>
+          </t>
+          <t>
+            <list style="symbols">
+              <t>Name: invalid_issuer</t>
+              <t>Usage Location: authorization endpoint</t>
+              <t>Protocol Extension: OpenID Federation</t>
+              <t>
+                Change Controller: OpenID Foundation Artifact Binding Working Group - openid-specs-ab@lists.openid.net
+              </t>
+              <t>Reference: <xref target="error_response"/> of this specification</t>
+            </list>
+          </t>
+          <t>
+            <list style="symbols">
+              <t>Name: invalid_subject</t>
+              <t>Usage Location: authorization endpoint</t>
+              <t>Protocol Extension: OpenID Federation</t>
+              <t>
+                Change Controller: OpenID Foundation Artifact Binding Working Group - openid-specs-ab@lists.openid.net
+              </t>
+              <t>Reference: <xref target="error_response"/> of this specification</t>
+            </list>
+          </t>
+          <t>
+            <list style="symbols">
               <t>Name: invalid_trust_anchor</t>
               <t>Usage Location: authorization endpoint</t>
               <t>Protocol Extension: OpenID Federation</t>
@@ -7446,7 +7491,7 @@ HTTP/1.1 302 Found
           </t>
           <t>
             <list style="symbols">
-              <t>Name: trust_chain_validation_failed</t>
+              <t>Name: invalid_trust_chain</t>
               <t>Usage Location: authorization endpoint</t>
               <t>Protocol Extension: OpenID Federation</t>
               <t>
@@ -7455,7 +7500,61 @@ HTTP/1.1 302 Found
               <t>Reference: <xref target="error_response"/> of this specification</t>
             </list>
           </t>
-	  <!-- TBD also register the error codes defined at anchor="error_response" -->
+          <t>
+            <list style="symbols">
+              <t>Name: invalid_metadata</t>
+              <t>Usage Location: authorization endpoint</t>
+              <t>Protocol Extension: OpenID Federation</t>
+              <t>
+                Change Controller: OpenID Foundation Artifact Binding Working Group - openid-specs-ab@lists.openid.net
+              </t>
+              <t>Reference: <xref target="error_response"/> of this specification</t>
+            </list>
+          </t>
+          <t>
+            <list style="symbols">
+              <t>Name: not_found</t>
+              <t>Usage Location: authorization endpoint</t>
+              <t>Protocol Extension: OpenID Federation</t>
+              <t>
+                Change Controller: OpenID Foundation Artifact Binding Working Group - openid-specs-ab@lists.openid.net
+              </t>
+              <t>Reference: <xref target="error_response"/> of this specification</t>
+            </list>
+          </t>
+          <t>
+            <list style="symbols">
+              <t>Name: server_error</t>
+              <t>Usage Location: authorization endpoint</t>
+              <t>Protocol Extension: OpenID Federation</t>
+              <t>
+                Change Controller: OpenID Foundation Artifact Binding Working Group - openid-specs-ab@lists.openid.net
+              </t>
+              <t>Reference: <xref target="error_response"/> of this specification</t>
+            </list>
+          </t>
+          <t>
+            <list style="symbols">
+              <t>Name: temporarily_unavailable</t>
+              <t>Usage Location: authorization endpoint</t>
+              <t>Protocol Extension: OpenID Federation</t>
+              <t>
+                Change Controller: OpenID Foundation Artifact Binding Working Group - openid-specs-ab@lists.openid.net
+              </t>
+              <t>Reference: <xref target="error_response"/> of this specification</t>
+            </list>
+          </t>
+          <t>
+            <list style="symbols">
+              <t>Name: unsupported_parameter</t>
+              <t>Usage Location: authorization endpoint</t>
+              <t>Protocol Extension: OpenID Federation</t>
+              <t>
+                Change Controller: OpenID Foundation Artifact Binding Working Group - openid-specs-ab@lists.openid.net
+              </t>
+              <t>Reference: <xref target="error_response"/> of this specification</t>
+            </list>
+          </t>
         </section>
         <?rfc subcompact="no"?>
       </section>
@@ -9833,7 +9932,11 @@ Host: op.umu.se
 	-41
 	<list style="symbols">
 	  <t>
-	    Fixed #136: Defined additional error codes.
+	    Fixed #136: Defined additional error codes and rationalized naming.
+	    Renamed <spanx style="verb">trust_chain_validation_failed</spanx>
+	    to <spanx style="verb">invalid_trust_chain</spanx> and
+	    renamed <spanx style="verb">missing_trust_anchor</spanx>
+	    to <spanx style="verb">invalid_trust_anchor</spanx>.
 	  </t>
 	  <t>
 	    Fixed #143: Added Trust Mark Issuer and Trust Mark Owner to Terminology section.

--- a/openid-federation-1_0.xml
+++ b/openid-federation-1_0.xml
@@ -5135,7 +5135,7 @@ Host: trust-anchor.example.com
 
       </section>
 
-      <section title="Error Responses from Federation Endpoints" anchor="error_response">
+      <section title="Error Responses" anchor="error_response">
         <t>
           If the request was malformed or an error occurred during
           the processing of the request,
@@ -5150,7 +5150,10 @@ Host: trust-anchor.example.com
           <list style="hanging">
             <t hangText="error">
               <vspace/>
-              REQUIRED. One of the following error codes SHOULD be used.
+	      REQUIRED.
+	      Error codes in the IANA "OAuth Extensions Error Registry"
+	      <xref target="IANA.OAuth.Parameters"/> MAY be used.
+	      This specification also defines the following error codes:
 
               <list style="hanging">
                 <t hangText="invalid_request">
@@ -5182,6 +5185,7 @@ Host: trust-anchor.example.com
 		</t>
 		<t hangText="trust_chain_validation_failed">
 		  <vspace/>
+		  The Trust Chain cannot be validated.
 		  The HTTP response status code SHOULD be 400 (Bad Request).
 		</t>
 		<t hangText="invalid_metadata">
@@ -5191,7 +5195,7 @@ Host: trust-anchor.example.com
 		</t>
                 <t hangText="not_found">
                   <vspace/>
-                  The requested Entity Identifier is "not found".
+                  The requested Entity Identifier cannot be found.
                   The HTTP response status code SHOULD be 404 (Not Found).
                 </t>
                 <t hangText="server_error">
@@ -5213,14 +5217,12 @@ Host: trust-anchor.example.com
                   The server does not support the requested parameter.
                 </t>
               </list>
-
-	      Other error codes in the IANA "OAuth Extensions Error Registry"
-	      <xref target="IANA.OAuth.Parameters"/> MAY also be used.
             </t>
 
             <t hangText="error_description">
               <vspace/>
-              REQUIRED. A human-readable short text describing the error.
+	      REQUIRED. Human-readable text providing additional information
+	      used to assist the developer in understanding the error that occurred.
             </t>
           </list>
         </t>

--- a/openid-federation-1_0.xml
+++ b/openid-federation-1_0.xml
@@ -6184,9 +6184,10 @@ redirect_uri=https%3A%2F%2Frp.example.com%2Fauthz_cb
 	    it MUST treat the redirection URI as invalid
 	    and not perform redirection.
 	    This means that the error codes
-	    <spanx style="verb">invalid_trust_anchor</spanx> and
-	    <spanx style="verb">invalid_trust_chain</spanx>
-	    both of which are about reasons trust failed to be established,
+	    <spanx style="verb">invalid_trust_anchor</spanx>,
+	    <spanx style="verb">invalid_trust_chain</spanx>, and
+	    <spanx style="verb">invalid_metadata</spanx>,
+	    which are about reasons trust failed to be established,
 	    SHOULD only be returned in
 	    <xref target="RFC9126">Pushed Authorization Request</xref>
 	    error responses, and not to the Client's redirection URI.

--- a/openid-federation-1_0.xml
+++ b/openid-federation-1_0.xml
@@ -87,7 +87,7 @@
       </address>
     </author>
 
-    <date day="6" month="November" year="2024"/>
+    <date day="19" month="November" year="2024"/>
 
     <workgroup>OpenID Connect Working Group</workgroup>
 
@@ -5158,11 +5158,31 @@ Host: trust-anchor.example.com
                   a valid participant of the federation.
                   The HTTP response status code SHOULD be 401 (Unauthorized).
                 </t>
-                 <t hangText="invalid_issuer">
+		<t hangText="invalid_issuer">
                   <vspace/>
                   The endpoint cannot service the requested issuer.
                   The HTTP response status code SHOULD be 404 (Not Found).
                 </t>
+		<t hangText="invalid_subject">
+		  <vspace/>
+		  The endpoint cannot service the requested subject.
+		  The HTTP response status code SHOULD be 404 (Not Found).
+		</t>
+		<t hangText="invalid_trust_anchor">
+		  <vspace/>
+		  The Trust Anchor cannot be found or used.
+		  The HTTP response status code SHOULD be 404 (Not Found).
+		</t>
+		<t hangText="invalid_trust_chain">
+		  <vspace/>
+		  A Trust Chain cannot be constructed or used.
+		  The HTTP response status code SHOULD be 404 (Not Found).
+		</t>
+		<t hangText="invalid_metadata">
+		  <vspace/>
+		  Metadata or Metadata Policy values are invalid or conflict.
+		  The HTTP response status code SHOULD be 400 (Bad Request).
+		</t>
                 <t hangText="not_found">
                   <vspace/>
                   The requested Entity Identifier is "not found".
@@ -6496,7 +6516,7 @@ HTTP/1.1 302 Found
 	      </t>
 	    </section>
 
-          <section anchor="cliregresp" title="Explicit Client Registration Response">
+          <section anchor="cliregresp" title="Successful Explicit Client Registration Response">
                   <t>
                     If the OP created a client registration for the RP, it MUST
                     then construct a success response in the form of an Entity Statement.
@@ -6634,9 +6654,12 @@ HTTP/1.1 302 Found
 		to prevent confusion between the Explicit Registration response
 		and normal Entity Statements.
               </t>
+	    </section>
+
+	    <section anchor="ExplicitError" title="Explicit Client Registration Error Response">
               <t>
                 For a client registration error, the response is as defined in
-                <xref target="error_response"/> and MAY use errors defined in
+                <xref target="error_response"/> and MAY use errors defined there and in
                 Section 3.3 of <xref target="OpenID.Registration"/> and
 		Section 3.2.2 of <xref target="RFC7591"/>.
               </t>
@@ -7432,6 +7455,7 @@ HTTP/1.1 302 Found
               <t>Reference: <xref target="AuthenticationError"/> of this specification</t>
             </list>
           </t>
+	  <!-- TBD also register the error codes defined at anchor="error_response" -->
         </section>
         <?rfc subcompact="no"?>
       </section>
@@ -9850,6 +9874,9 @@ Host: op.umu.se
       <t>
 	-41
 	<list style="symbols">
+	  <t>
+	    Fixed #136: Defined additional error codes.
+	  </t>
 	  <t>
 	    Fixed #105 and #106: Informatively say that the
 	    <spanx style="verb">require_signed_request_object</spanx>

--- a/openid-federation-1_0.xml
+++ b/openid-federation-1_0.xml
@@ -7425,13 +7425,13 @@ HTTP/1.1 302 Found
           <t>
             <?rfc subcompact="yes"?>
             <list style="symbols">
-              <t>Name: missing_trust_anchor</t>
+              <t>Name: invalid_trust_anchor</t>
               <t>Usage Location: authorization endpoint</t>
               <t>Protocol Extension: OpenID Federation</t>
               <t>
                 Change Controller: OpenID Foundation Artifact Binding Working Group - openid-specs-ab@lists.openid.net
               </t>
-              <t>Reference: <xref target="AuthenticationError"/> of this specification</t>
+              <t>Reference: <xref target="error_response"/> of this specification</t>
             </list>
           </t>
           <t>
@@ -7442,7 +7442,7 @@ HTTP/1.1 302 Found
               <t>
                 Change Controller: OpenID Foundation Artifact Binding Working Group - openid-specs-ab@lists.openid.net
               </t>
-              <t>Reference: <xref target="AuthenticationError"/> of this specification</t>
+              <t>Reference: <xref target="error_response"/> of this specification</t>
             </list>
           </t>
 	  <!-- TBD also register the error codes defined at anchor="error_response" -->


### PR DESCRIPTION
Fixes #136

Note that we probably also want to harmonize `missing_trust_anchor` with `invalid_trust_anchor` and `trust_chain_validation_failed` with `invalid_trust_chain`.
