### PR TITLE
Using non-interoperable JSON may result in unpredictable metadata and metadata policies (iss #35)

### DIFF
--- a/openid-federation-1_0.xml
+++ b/openid-federation-1_0.xml
@@ -2041,6 +2041,12 @@
                 An operator MUST NOT output a metadata parameter with the
                 <spanx style="verb">null</spanx> value.
               </t>
+              <t>
+                Metadata parameters and policies that conform to the JSON
+                grammar but are not interoperable uses of JSON, as per Sections
+                4 and 8 of <xref target="RFC8259"/>, may cause unpredictable
+                behavior.
+              </t>
 
             </list>
           </t>
@@ -8640,6 +8646,7 @@ HTTP/1.1 302 Found
       <xi:include href="https://bib.ietf.org/public/rfc/bibxml/reference.RFC.7591.xml"/>
       <xi:include href="https://bib.ietf.org/public/rfc/bibxml/reference.RFC.7638.xml"/>
       <xi:include href="https://bib.ietf.org/public/rfc/bibxml/reference.RFC.8174.xml"/>
+      <xi:include href="https://bib.ietf.org/public/rfc/bibxml/reference.RFC.8259.xml"/>
       <xi:include href="https://bib.ietf.org/public/rfc/bibxml/reference.RFC.8414.xml"/>
       <xi:include href="https://bib.ietf.org/public/rfc/bibxml/reference.RFC.8705.xml"/>
       <xi:include href="https://bib.ietf.org/public/rfc/bibxml/reference.RFC.9101.xml"/>
@@ -10056,6 +10063,11 @@ Host: op.umu.se
 	    Also corrected the <spanx style="verb">authority_hints</spanx> value
 	    in the Explicit Registration response to be the Immediate Superior
 	    of the RP in the Trust Chain selected for it by the OP.
+	  </t>
+	  <t>
+	    Fixed #35: Clarified that using non-interoperable JSON, as per sections
+        4 and 8 of RFC 8259, may result in unpredictable metadata and metadata
+        policy behavior.
 	  </t>
 	</list>
       </t>

--- a/openid-federation-1_0.xml
+++ b/openid-federation-1_0.xml
@@ -2042,9 +2042,10 @@
                 <spanx style="verb">null</spanx> value.
               </t>
               <t>
-                Metadata parameters and policies that conform to the JSON
-                grammar but are not interoperable uses of JSON, as per Sections
-                4 and 8 of <xref target="RFC8259"/>, may cause unpredictable
+                Metadata parameters and policies that conform to the JSON 
+                grammar but do not represent interoperable uses of JSON,
+                as per Sections 4 and 8 of <xref target="RFC8259"/>, 
+                may cause unpredictable
                 behavior.
               </t>
 


### PR DESCRIPTION
To address the root issue of #35  - how to deal with JSON object values in metadata policies and metadata.

This was adopted from the JSON Path RFC, which language must exhibit predictable behaviour, but this isn't guaranteed when the JSON is non-interoperable (e.g. has duplicate JSON object member names):

https://www.rfc-editor.org/rfc/rfc9535#name-json-values

> The parsing of a JSON text into a JSON value and what happens if a JSON text does not represent valid JSON are not defined by this document. Sections [4](https://rfc-editor.org/rfc/rfc8259#section-4) and [8](https://rfc-editor.org/rfc/rfc8259#section-8) of [[RFC8259](https://www.rfc-editor.org/rfc/rfc9535#RFC8259)] identify specific situations that may conform to the grammar for JSON texts but are not interoperable uses of JSON, as they may cause unpredictable behavior. This document does not attempt to define predictable behavior for JSONPath queries in these situations

