### PR TITLE
Adjust and simplify policy operator combinations

### DIFF
--- a/openid-federation-1_0.xml
+++ b/openid-federation-1_0.xml
@@ -2087,6 +2087,32 @@
                 Combination with other operators in a metadata parameter policy:
                 <list style="symbols">
                   <t>
+                    MAY be combined with <spanx style="verb">add</spanx>,
+                    in which case the values of <spanx style="verb">add</spanx>
+                    MUST be a subset of the values of
+                    <spanx style="verb">value</spanx>.
+                  </t>
+                  <t>
+                    MAY be combined with <spanx style="verb">default</spanx>.
+                  </t>
+                  <t>
+                    MAY be combined with <spanx style="verb">one_of</spanx>,
+                    in which case the value of <spanx style="verb">value</spanx>
+                    MUST be among the <spanx style="verb">one_of</spanx> values.
+                  </t>
+                  <t>
+                    MAY be combined with <spanx style="verb">subset_of</spanx>,
+                    in which case the values of <spanx style="verb">value</spanx>
+                    MUST be a subset of the values of
+                    <spanx style="verb">subset_of</spanx>.
+                  </t>
+                  <t>
+                    MAY be combined with <spanx style="verb">superset_of</spanx>,
+                    in which case the values of <spanx style="verb">value</spanx>
+                    MUST be a superset of the values of
+                    <spanx style="verb">superset_of</spanx>.
+                  </t>
+                  <t>
                     MAY be combined with <spanx style="verb">essential</spanx>.
                   </t>
                 </list>
@@ -2137,6 +2163,12 @@
                 Combination with other operators in a metadata parameter policy:
                 <list style="symbols">
                   <t>
+                    MAY be combined with <spanx style="verb">value</spanx>,
+                    in which case the values of <spanx style="verb">add</spanx>
+                    MUST be a subset of the values of
+                    <spanx style="verb">value</spanx>.
+                  </t>
+                  <t>
                     MAY be combined with <spanx style="verb">default</spanx>.
                   </t>
                   <t>
@@ -2146,10 +2178,7 @@
                     <spanx style="verb">subset_of</spanx>.
                   </t>
                   <t>
-                    MAY be combined with <spanx style="verb">superset_of</spanx>,
-                    in which case the values of <spanx style="verb">add</spanx>
-                    MUST be a superset of the values of
-                    <spanx style="verb">superset_of</spanx>.
+                    MAY be combined with <spanx style="verb">superset_of</spanx>.
                   </t>
                   <t>
                     MAY be combined with <spanx style="verb">essential</spanx>.
@@ -2195,24 +2224,19 @@
                 Combination with other operators in a metadata parameter policy:
                 <list style="symbols">
                   <t>
+                    MAY be combined with <spanx style="verb">value</spanx>.
+                  </t>
+                  <t>
                     MAY be combined with <spanx style="verb">add</spanx>.
                   </t>
                   <t>
-                    MAY be combined with <spanx style="verb">one_of</spanx>, in
-                    which case the <spanx style="verb">default</spanx> value
-                    MUST be among the <spanx style="verb">one_of</spanx> values.
+                    MAY be combined with <spanx style="verb">one_of</spanx>.
                   </t>
                   <t>
-                    MAY be combined with <spanx style="verb">subset_of</spanx>,
-                    in which case the <spanx style="verb">default</spanx> values
-                    MUST be a subset of the <spanx style="verb">subset_of</spanx>
-                    values.
+                    MAY be combined with <spanx style="verb">subset_of</spanx>.
                   </t>
                   <t>
-                    MAY be combined with <spanx style="verb">superset_of</spanx>,
-                    in which case the <spanx style="verb">default</spanx> values
-                    MUST be a superset of the
-                    <spanx style="verb">superset_of</spanx> values.
+                    MAY be combined with <spanx style="verb">superset_of</spanx>.
                   </t>
                   <t>
                     MAY be combined with <spanx style="verb">essential</spanx>.
@@ -2262,9 +2286,12 @@
                 Combination with other operators in a metadata parameter policy:
                 <list style="symbols">
                   <t>
-                    MAY be combined with <spanx style="verb">default</spanx>,
-                    in which case the value of default MUST be among the
-                    <spanx style="verb">one_of</spanx> values.
+                    MAY be combined with <spanx style="verb">value</spanx>,
+                    in which case the value of <spanx style="verb">value</spanx>
+                    MUST be among the <spanx style="verb">one_of</spanx> values.
+                  </t>
+                  <t>
+                    MAY be combined with <spanx style="verb">default</spanx>.
                   </t>
                   <t>
                     MAY be combined with <spanx style="verb">essential</spanx>.
@@ -2322,16 +2349,19 @@
                 Combination with other operators in a metadata parameter policy:
                 <list style="symbols">
                   <t>
+                    MAY be combined with <spanx style="verb">value</spanx>,
+                    in which case the values of <spanx style="verb">value</spanx>
+                    MUST be a subset of the values of
+                    <spanx style="verb">subset_of</spanx>.
+                  </t>
+                  <t>
                     MAY be combined with <spanx style="verb">add</spanx>, in
                     which case the values of <spanx style="verb">add</spanx>
                     MUST be a subset of the values of
                     <spanx style="verb">subset_of</spanx>.
                   </t>
                   <t>
-                    MAY be combined with <spanx style="verb">default</spanx>, in
-                    which case the values of <spanx style="verb">default</spanx>
-                    MUST be a subset of the values of
-                    <spanx style="verb">subset_of</spanx>.
+                    MAY be combined with <spanx style="verb">default</spanx>.
                   </t>
                   <t>
                     MAY be combined with <spanx style="verb">superset_of</spanx>,
@@ -2390,16 +2420,16 @@
                 Combination with other operators in a metadata parameter policy:
                 <list style="symbols">
                   <t>
-                    MAY be combined with <spanx style="verb">add</spanx>, in
-                    which case the values of <spanx style="verb">add</spanx>
+                    MAY be combined with <spanx style="verb">value</spanx>,
+                    in which case the values of <spanx style="verb">value</spanx>
                     MUST be a superset of the values of
                     <spanx style="verb">superset_of</spanx>.
                   </t>
                   <t>
-                    MAY be combined with <spanx style="verb">default</spanx>, in
-                    which case the values of <spanx style="verb">default</spanx>
-                    MUST be a superset of the values of
-                    <spanx style="verb">superset_of</spanx>.
+                    MAY be combined with <spanx style="verb">add</spanx>.
+                  </t>
+                  <t>
+                    MAY be combined with <spanx style="verb">default</spanx>.
                   </t>
                   <t>
                     MAY be combined with <spanx style="verb">subset_of</spanx>,
@@ -10050,6 +10080,18 @@ Host: op.umu.se
       <t>
 	-42
 	<list style="symbols">
+      <t>
+       Addresses #11:
+
+       Allows the following unconditional operator combinations:
+       value + default, add + superset_of.
+
+       Makes the following previously conditional operator combinations unconditional:
+       default + one_of, default + subset_of, default + superset_of.
+
+       Allows the following conditional operator combinations:
+       value + add, value + one_of, value + subset_of, value + superset_of.
+      </t>
 	  <t>
 	    Fixed #130: Allow multiple Trust Anchor values to be passed in resolve requests.
 	  </t>

--- a/openid-federation-1_0.xml
+++ b/openid-federation-1_0.xml
@@ -2120,7 +2120,9 @@
                     <spanx style="verb">superset_of</spanx>.
                   </t>
                   <t>
-                    MAY be combined with <spanx style="verb">essential</spanx>.
+                    MAY be combined with <spanx style="verb">essential</spanx>,
+                    except when <spanx style="verb">value</spanx> is null and
+                    <spanx style="verb">essential</spanx> is true.
                   </t>
                 </list>
               </t>
@@ -2493,6 +2495,11 @@
               <t>
                 Combination with other operators in a metadata parameter policy:
                 <list style="symbols">
+                  <t>
+                    MAY be combined with <spanx style="verb">value</spanx>,
+                    except when <spanx style="verb">value</spanx> is null and
+                    <spanx style="verb">essential</spanx> is true.
+                  </t>
                   <t>
                     MAY be combined with any other operator.
                   </t>
@@ -10090,13 +10097,16 @@ Host: op.umu.se
 	-42
 	<list style="symbols">
       <t>
-       Addresses #11:
+       Addresses #11, #180:
 
        Allows the following unconditional operator combinations:
        add + superset_of.
 
        Makes the following previously conditional operator combinations unconditional:
        default + one_of, default + subset_of, default + superset_of.
+
+       Makes the following previously unconditional operator combination conditional:
+       value + essential.
 
        Allows the following conditional operator combinations:
        value + add, value + default, value + one_of, value + subset_of, value + superset_of.

--- a/openid-federation-1_0.xml
+++ b/openid-federation-1_0.xml
@@ -2390,8 +2390,9 @@
               <t>
                 Operator value merge: The result of merging the values of two
                 <spanx style="verb">subset_of</spanx> operators is the
-                intersection of the operator values. If the intersection is
-                empty, this MUST produce a policy error.
+                intersection of the operator values. Note that the resulting
+                intersection may thus be an empty array
+                <spanx style="verb">[]</spanx>.
               </t>
             </section>
 
@@ -10115,7 +10116,8 @@ Host: op.umu.se
       parameter, if the resulting intersection is empty, then the metadata is
       made empty. Previously it was removed, which may lead to policy override
       for metadata parameters that a have default value, for instance
-      grant_types RP metadata or grant_types_supported OP metadata.
+      grant_types RP metadata or grant_types_supported OP metadata. The merge of
+      two subset_of operators is changed to allow empty intersection as well.
       </t>
       <t>
        Addresses #129: Clarifies that the combination rules for a metadata

--- a/openid-federation-1_0.xml
+++ b/openid-federation-1_0.xml
@@ -2098,7 +2098,9 @@
                     <spanx style="verb">value</spanx>.
                   </t>
                   <t>
-                    MAY be combined with <spanx style="verb">default</spanx>.
+                    MAY be combined with <spanx style="verb">default</spanx>
+                    if the value of <spanx style="verb">value</spanx> is not
+                    null.
                   </t>
                   <t>
                     MAY be combined with <spanx style="verb">one_of</spanx>,
@@ -2229,7 +2231,9 @@
                 Combination with other operators in a metadata parameter policy:
                 <list style="symbols">
                   <t>
-                    MAY be combined with <spanx style="verb">value</spanx>.
+                    MAY be combined with <spanx style="verb">value</spanx>
+                    if the value  of <spanx style="verb">value</spanx> is not
+                    null.
                   </t>
                   <t>
                     MAY be combined with <spanx style="verb">add</spanx>.
@@ -10089,13 +10093,13 @@ Host: op.umu.se
        Addresses #11:
 
        Allows the following unconditional operator combinations:
-       value + default, add + superset_of.
+       add + superset_of.
 
        Makes the following previously conditional operator combinations unconditional:
        default + one_of, default + subset_of, default + superset_of.
 
        Allows the following conditional operator combinations:
-       value + add, value + one_of, value + subset_of, value + superset_of.
+       value + add, value + default, value + one_of, value + subset_of, value + superset_of.
       </t>
       <t>
        Addresses #129: Clarifies that the combination rules for a metadata

--- a/openid-federation-1_0.xml
+++ b/openid-federation-1_0.xml
@@ -2127,7 +2127,7 @@
               </t>
               <t>
                 Operator value merge: Allowed only when the operator values are
-                equal. If not, this MUST result in a policy error.
+                equal. If not, this MUST produce a policy error.
               </t>
             </section>
 
@@ -2253,7 +2253,7 @@
               </t>
               <t>
                 Operator value merge: The operator values MUST be equal. If the
-                values are not equal this MUST result in a policy error.
+                values are not equal this MUST produce a policy error.
               </t>
             </section>
 
@@ -2386,7 +2386,7 @@
                 Operator value merge: The result of merging the values of two
                 <spanx style="verb">subset_of</spanx> operators is the
                 intersection of the operator values. If the intersection is
-                empty, this MUST result in a policy error.
+                empty, this MUST produce a policy error.
               </t>
             </section>
 
@@ -2639,8 +2639,8 @@
               Statement claim, in which case the operator MUST be understood
               and processed. If an additional operator listed in
               <spanx style="verb">metadata_policy_crit</spanx> is not understood
-              or cannot be processed, then this MUST result in a policy error
-              and the Trust Chain MUST be considered invalid.
+              or cannot be processed, then this MUST produce a policy error and
+              the Trust Chain MUST be considered invalid.
             </t>
 
           </section>
@@ -2689,7 +2689,7 @@
               </t>
 
               <t>
-                An important procedure during the iteration is the
+                An important task during the iteration is the
                 <spanx style="verb">metadata_policy</spanx> validation. It MUST
                 ensure the data structure is compliant and that every metadata
                 parameter policy contains only allowed operator combinations, as
@@ -2699,7 +2699,7 @@
                 contains no operators that cannot be understood and processed
                 whose names are among the collected
                 <spanx style="verb">metadata_policy_crit</spanx> values. An
-                unsuccessful validation MUST result in a policy error.
+                unsuccessful validation MUST produce a policy error.
               </t>
 
               <t>
@@ -2719,7 +2719,7 @@
               </t>
 
               <t>
-                The merge is performed at all three levels of the
+                The merge is performed at each of the three levels of the
                 <spanx style="verb">metadata_policy</spanx> data structure
                 described in <xref target="metadata_policy_structure"/>, by
                 starting from the top level:
@@ -2776,7 +2776,7 @@
                       that are not allowed, as described in
                       <xref target="metadata_policy_operators"/> and in
                       accordance with the specifications of the operators, this
-                      MUST result in a policy error.
+                      MUST produce a policy error.
                     </t>
                     <t>
                       Subordinate metadata parameter policies that are not
@@ -2798,7 +2798,7 @@
                       <xref target="metadata_policy_operators"/> and in
                       accordance with the operator specification. If an operator
                       value merge is not allowed or otherwise unsuccessful this
-                      MUST result in a policy error.
+                      MUST produce a policy error.
                     </t>
                     <t>
                       Subordinate operators that are not present in the current

--- a/openid-federation-1_0.xml
+++ b/openid-federation-1_0.xml
@@ -2329,9 +2329,8 @@
                 intersection between the values of the operator and the
                 metadata parameter. Note that the resulting intersection may
                 thus be an empty array <spanx style="verb">[]</spanx>. Also note
-                that this behavior makes <spanx style="verb">subset_of</spanx>
-                a potential value modifier in addition to it being a value
-                check.
+                that <spanx style="verb">subset_of</spanx> is a potential value
+                modifier in addition to it being a value check.
               </t>
               <t>
                 Metadata parameter JSON values:

--- a/openid-federation-1_0.xml
+++ b/openid-federation-1_0.xml
@@ -2325,14 +2325,13 @@
                 Name: <spanx style="verb">subset_of</spanx>
               </t>
               <t>
-                Action: If the metadata parameter is present, this operator
-                computes the intersection between the values of the operator and
-                the metadata parameter. If the intersection is non-empty, the
-                metadata parameter is set to the values in the intersection. If
-                the intersection is empty, the metadata parameter MUST be
-                removed. Note that this behavior makes
-                <spanx style="verb">subset_of</spanx> a potential value modifier
-                in addition to it being a value check.
+                Action: If the metadata parameter is present, it is assigned the
+                intersection between the values of the operator and the
+                metadata parameter. Note that the resulting intersection may
+                thus be an empty array <spanx style="verb">[]</spanx>. Also note
+                that this behavior makes <spanx style="verb">subset_of</spanx>
+                a potential value modifier in addition to it being a value
+                check.
               </t>
               <t>
                 Metadata parameter JSON values:
@@ -10110,6 +10109,13 @@ Host: op.umu.se
 
        Allows the following conditional operator combinations:
        value + add, value + default, value + one_of, value + subset_of, value + superset_of.
+      </t>
+      <t>
+      Addresses #182: When applying the subset_of operator on a metadata
+      parameter, if the resulting intersection is empty, then the metadata is
+      made empty. Previously it was removed, which may lead to policy override
+      for metadata parameters that a have default value, for instance
+      grant_types RP metadata or grant_types_supported OP metadata.
       </t>
       <t>
        Addresses #129: Clarifies that the combination rules for a metadata

--- a/openid-federation-1_0.xml
+++ b/openid-federation-1_0.xml
@@ -2018,9 +2018,14 @@
                 a policy error.
               </t>
               <t>
-                MUST declare what other operators it may be combined within a
-                metadata parameter policy. Combinations that are not allowed
-                MUST result in a policy error.
+                MUST declare what other operators it may be combined with,
+                which applies to both individual as well as merged metadata
+                parameter policies, as described in
+                <xref target="metadata_policy_structure"/> and
+                <xref target="metadata_policy_enforcement"/>. A combination may
+                be unconditional, or conditional, requiring the configured
+                values of the two operators to meet certain criteria.
+                Combinations that are not allowed MUST produce a policy error.
               </t>
               <t>
                 MUST declare in what order it is to be applied to a metadata
@@ -10091,6 +10096,11 @@ Host: op.umu.se
 
        Allows the following conditional operator combinations:
        value + add, value + one_of, value + subset_of, value + superset_of.
+      </t>
+      <t>
+       Addresses #129: Clarifies that the combination rules for a metadata
+       policy operator apply to both individual as well as merged metadata
+       parameter policies.
       </t>
 	  <t>
 	    Fixed #130: Allow multiple Trust Anchor values to be passed in resolve requests.


### PR DESCRIPTION
Addresses issues #11 , #129 , #180.

The chief aim of this PR is to make it easier for architects to devise metadata policies in federations with multiple Trust Anchors or federations with complex topologies. In a single-anchored federation the current, limited operator combinations were okay, because one can simply lookup the policies of the Superior(s) and tweak the local policy where necessary. When dealing with multiple Trust Anchors the limited combinations become a problem. This PR fixes that. It also fixes the `value` + `essential` combination, which current spec may lead to policy conflict (#180).

This PR incorporates the contributions of @zachmann from PRs #111 and #112 (thanks!), with slight edits , plus several additional combination changes.

The proposed combinations were implemented in the Nimbus OIDC / OAuth SDK and were tested, including tests against a suite of several thousand generated test vectors: https://connect2id.com/blog/metadata-policy-test-vectors-openid-federation

The proposed combinations changes + fix, as a table:

![image](https://github.com/user-attachments/assets/7de32a86-4039-4851-a899-3b591988b1b0)


The combinations in draft 41, for comparison. Notice that the updated version has more green or yellow squares for policies to "land", as it covers all logical combinations.

![image](https://github.com/user-attachments/assets/aad6e7fe-d259-45f4-8441-8f3e7fe1f534)

This PR also tightens the language in a few places.
