### PR TITLE
fix: naming constraints example

### DIFF
--- a/openid-federation-1_0.xml
+++ b/openid-federation-1_0.xml
@@ -3135,10 +3135,10 @@
   "max_path_length": 2,
   "naming_constraints": {
     "permitted": [
-      "https://.example.com"
+      ".example.com"
     ],
     "excluded": [
-      "https://east.example.com"
+      "east.example.com"
     ]
   },
   "allowed_entity_types": [


### PR DESCRIPTION
As per the RFC 5280, `naming constraints` applied to URIs `MUST be specified as a fully qualified domain name and MAY specify a host or a domain. Examples would be "host.example.com" and ".example.com"`.

The current specification incorrectly shows examples with URI scheme prefixes, such as "https://.example.com", which do not conform to RFC 5280.