### PR TITLE
It is specifically the trust_mark_id claims that matters.

### DIFF
--- a/openid-federation-1_0.xml
+++ b/openid-federation-1_0.xml
@@ -653,9 +653,9 @@
               OPTIONAL. An array of JSON objects, each representing
               a Trust Mark.
               Each JSON object MUST contain the following two claims
-              and MAY contain other claims. All the claims in the
-              JSON object MUST have the same values as those
-              contained in the Trust Mark JWT.
+              and MAY contain other claims. The <spanx style="verb">trust_mark_id</spanx>
+                claim in this object MUST have the same value as the
+              <spanx style="verb">trust_mark_id</spanx> claim in the Trust Mark JWT.
 
               <list style="hanging">
                 <t hangText="trust_mark_id">


### PR DESCRIPTION
Saying **All** claims is just to open ended.