### PR TITLE
Fixes the policy operators examples table: output of rows 3 and 4 must be empty JSON array (iss #196)

### DIFF
--- a/openid-federation-1_0.xml
+++ b/openid-federation-1_0.xml
@@ -2587,14 +2587,14 @@
                     <td>true</td>
                     <td>[a,b,c]</td>
                     <td>[d,e]</td>
-                    <td>error</td>
+                    <td>[]</td>
                   </tr>
 
                   <tr>
                     <td>false</td>
                     <td>[a,b,c]</td>
                     <td>[d,e]</td>
-                    <td>no parameter</td>
+                    <td>[]</td>
                   </tr>
 
                   <tr>
@@ -10094,9 +10094,11 @@ Host: op.umu.se
       <t>
 	-43
 	<list style="symbols">
-	  <t>
-	    TBD
-	  </t>
+      <t  >
+          Fixes #196: The output of rows 3 and 4 in Table 1: Examples of
+          Outputs with Combinations of essential and subset_of for Different
+          Inputs must be empty JSON array []
+      </t>
 	</list>
       </t>
 


### PR DESCRIPTION
The outputs of rows and 3 and 4 must be empty JSON array [].

This aligns the examples with the spec update for iss #182 .