### PR TITLE
different signing algorithms for different Entity Statements in a Trust Chains

### DIFF
--- a/openid-federation-1_0.xml
+++ b/openid-federation-1_0.xml
@@ -10143,12 +10143,12 @@ Host: op.umu.se
 	  <t>
 	    OAuth 2.0 Protected Resource Metadata is now RFC 9728.
 	  </t>
-      <t>
-        Follow Implementation Considerations in <xref target="OpenID.RP.Choices"/>.
-      </t>
-      <t>
-        Added note about using different signing algorithms for different Entity Statements in a Trust Chain.
-      </t>
+    <t>
+      Follow Implementation Considerations in <xref target="OpenID.RP.Choices"/>.
+     </t>
+     <t>
+      Added note about using different signing algorithms for different Entity Statements in a Trust Chain.
+     </t>
 	</list>
       </t>
 

--- a/openid-federation-1_0.xml
+++ b/openid-federation-1_0.xml
@@ -492,9 +492,9 @@
           requires support for it (<spanx style="verb">alg</spanx>
           value of <spanx style="verb">RS256</spanx>).
           Federations MAY also specify different mandatory-to-implement algorithms.
-          Note that a Trust Chain can be composed of Entity Statements signed using different
-          signing algorithms, as long as each statement's signature uses a signature algorithm
-          supported by the trust framework in use.
+          Note that a Trust Chain can contain Entity Statements signed using different
+          signing algorithms, as long as each signature uses a signature algorithm
+          supported by the trust framework and implementations in use.
         </t>
 	<t>
 	  Entity Statement JWTs MUST include the

--- a/openid-federation-1_0.xml
+++ b/openid-federation-1_0.xml
@@ -492,6 +492,9 @@
           requires support for it (<spanx style="verb">alg</spanx>
           value of <spanx style="verb">RS256</spanx>).
           Federations MAY also specify different mandatory-to-implement algorithms.
+          Note that a Trust Chain can be composed of Entity Statements signed using different
+          signing algorithms, as long as each statement's signature uses a signature algorithm
+          supported by the trust framework in use.
         </t>
 	<t>
 	  Entity Statement JWTs MUST include the
@@ -10140,9 +10143,12 @@ Host: op.umu.se
 	  <t>
 	    OAuth 2.0 Protected Resource Metadata is now RFC 9728.
 	  </t>
-	  <t>
-	    Follow Implementation Considerations in <xref target="OpenID.RP.Choices"/>.
-	  </t>
+      <t>
+        Follow Implementation Considerations in <xref target="OpenID.RP.Choices"/>.
+      </t>
+      <t>
+        Added note about using different signing algorithms for different Entity Statements in a Trust Chain.
+      </t>
 	</list>
       </t>
 


### PR DESCRIPTION
Added note about using different signing algorithms for different Entity Statements in a Trust Chain.

@selfissued I would appreciate to add normaitve reference to standards defining the supported algorithm and the security best current practice to exclude the deprecated/weak ones. 