### PR TITLE
clear up statement about trust_mark_owners and trust_mark_issuers for…

### DIFF
--- a/openid-federation-1_0.xml
+++ b/openid-federation-1_0.xml
@@ -3544,9 +3544,9 @@
             the Trust Mark Owner and that the
             Trust Mark Owner has delegated the right to issue Trust Marks
             with a designated Trust Mark identifier to a specified Trust Mark Issuer.
-            Also, the Trust Anchor MAY provide an empty array for the Trust Mark identifier to
-            signal that that this Trust Mark can be issued by all the Trust Mark Issuers the
-            Trust Mark Owner has delegated the right to.
+            Also, the Trust Anchor MAY provide an empty array following the Trust Mark Identifier
+            to signal that this Trust Mark can be issued by any Trust Mark Issuer to which the
+            Trust Mark Owner has delegated the right to do so.
           </t>
           <t>
             Trust Marks that are not recognized within a federation SHOULD be ignored when

--- a/openid-federation-1_0.xml
+++ b/openid-federation-1_0.xml
@@ -3536,15 +3536,17 @@
             in its Entity Configuration to publish this information.
           </t>
           <t>
-            If a Trust Mark Issuer is issuing Trust Marks on behalf of a
-            Trust Mark Owner, then the Trust Anchor MUST publish the
-            connection between the Trust Mark identifier
-	    and the corresponding Trust Mark Issuer in the
+            If a Trust Mark is issued on behalf of a Trust Mark Owner, then the Trust Anchor SHOULD
+            publish the connection between the Trust Mark identifier
+	          and the corresponding Trust Mark Issuer in the
             <spanx style="verb">trust_mark_issuers</spanx> claim. This
             signifies that the Trust Anchor has validated
             the Trust Mark Owner and that the
             Trust Mark Owner has delegated the right to issue Trust Marks
             with a designated Trust Mark identifier to a specified Trust Mark Issuer.
+            Also, the Trust Anchor MAY provide an empty array for the Trust Mark identifier to
+            signal that that this Trust Mark can be issued by all the Trust Mark Issuers the
+            Trust Mark Owner has delegated the right to.
           </t>
           <t>
             Trust Marks that are not recognized within a federation SHOULD be ignored when


### PR DESCRIPTION
… delegated trust marks

Fixes #123 

This relates to delegated trust marks, and the information a TA publishes in `trust_mark_issuers` for such trust marks.

This includes two changes:
- Changes `MUST` to `SHOULD`, since it is generally optional to publish information in  `trust_mark_issuers`, I don't see a reason why it must be a MUST for delegated trust marks.
- Explicitly state that the TA can provide the empty array to accept all Trust Mark Issuers (within the federation) that the Trust Mark Owner has delegated to