### PR TITLE
Add additional ui related claims for all metadata types.

### DIFF
--- a/openid-federation-1_0.xml
+++ b/openid-federation-1_0.xml
@@ -1769,6 +1769,21 @@
               this MAY be, for example, the person's name. Note
               that this information will be publicly available.
             </t>
+            <t hangText="display_name">
+              <vspace/>
+              OPTIONAL. A human-readable
+              name of the Entity to be presented to the End-User.
+            </t>
+            <t hangText="description">
+              <vspace/>
+              OPTIONAL. A human-readable, brief description of this Entity
+              presentable to the End-User.
+            </t>
+            <t hangText="keywords">
+              <vspace/>
+              OPTIONAL. JSON array with one or more
+              strings representing search keywords, tags, categories, or labels that apply to this Entity.
+            </t>
             <t hangText="contacts">
               <vspace/>
               OPTIONAL. JSON array with one or more
@@ -1786,6 +1801,11 @@
               <vspace/>
               OPTIONAL. URL of the documentation of
               conditions and policies relevant to this Entity.
+            </t>
+            <t hangText="information_uri">
+              <vspace/>
+              OPTIONAL. URL of the documentation of
+              additional information about this Entity meant to be viewed by the End-User.
             </t>
             <t hangText="homepage_uri">
               <vspace/>


### PR DESCRIPTION
As we are currently working on a draft for an [Entity Collection Endpoint](https://github.com/zachmann/openid-federation-entity-collection) we found the need for additional metadata claims.

This allows that Entities publish this information in their Entity Configuration and the entity collection endpoint can return the information which then among other use-cases allows to build UIs so End-Users can select an OP.

This PR adds the following claims as **optional** metadata claims that can be used with all entity types:

- display_name
- description
- keywords
- information_uri

This is also inspired by https://docs.oasis-open.org/security/saml/Post2.0/sstc-saml-metadata-ui/v1.0/os/sstc-saml-metadata-ui-v1.0-os.html

I tried to mimic the information specified there, where `policy_uri` and `logo_uri` is already defined in oidfed.

The already existing `organization_name` claim is semantically different from `display_name`, since display name is about the entity and not the organization.