### PR TITLE
Define how to validate Entity Statements

### DIFF
--- a/openid-federation-1_0.xml
+++ b/openid-federation-1_0.xml
@@ -87,7 +87,7 @@
       </address>
     </author>
 
-    <date day="26" month="May" year="2025"/>
+    <date day="27" month="May" year="2025"/>
 
     <workgroup>OpenID Connect Working Group</workgroup>
 
@@ -759,6 +759,100 @@
           and use additional claims.
         </t>
 
+	<section anchor="ESValidation" title="Entity Statement Validation">
+	  <t>
+	    Entity Statements MUST be validated in the following manner.
+	    These steps MAY be performed in a different order, provided that
+	    the result - accepting or rejecting the Entity Statement - is the same.
+	    <list style="numbers">
+	      <t>
+		The Entity Statement MUST be a signed JWT.
+	      </t>
+	      <t>
+		The Entity Statement MUST have a
+		<spanx style="verb">typ</spanx> header parameter with the value
+		<spanx style="verb">entity-statement+jwt</spanx>.
+	      </t>
+	      <t>
+		The Entity Statement MUST have an
+		<spanx style="verb">alg</spanx> (algorithm) header parameter
+		with a value that is an acceptable JWS signing algorithm;
+		it MUST NOT be <spanx style="verb">none</spanx>.
+	      </t>
+	      <t>
+		The Entity Identifier of the Entity
+		MUST exactly match the value of the
+		<spanx style="verb">sub</spanx> (subject) Claim.
+	      </t>
+	      <t>
+		The Entity Statement MUST have an
+		<spanx style="verb">iss</spanx> (issuer) Claim
+		with a value that is a valid Entity Identifier.
+	      </t>
+	      <t>
+		Either the <spanx style="verb">iss</spanx> (issuer) Claim value
+		MUST exactly match
+		the <spanx style="verb">sub</spanx> (subject) Claim value,
+		in which case the Entity Statement is this Entity's Entity Configuration,
+		or it MUST exactly match one of the values in the
+		<spanx style="verb">authority_hints</spanx> array,
+		which MUST be present when the <spanx style="verb">iss</spanx>
+		and <spanx style="verb">sub</spanx> Claim values differ
+	      </t>
+	      <t>
+		The current time MUST be after the time represented by the
+		<spanx style="verb">iat</spanx> (issued at) Claim.
+	      </t>
+	      <t>
+		The current time MUST be before the time represented by the
+		<spanx style="verb">exp</spanx> (expiration) Claim.
+	      </t>
+	      <t>
+		The <spanx style="verb">jwks</spanx> (JWK Set) Claim
+		MUST be present, with a value that is a valid
+		JWK Set <xref target="RFC7517"/>.
+	      </t>
+	      <t>
+		If the <spanx style="verb">jwks</spanx> (critical) Claim is present,
+		then for each array element in this claim's value,
+		the Entity Statement MUST contain a claim with the same name
+		as the array element, and that claim MUST be understood
+		and be able to be processed by the implementation.
+	      </t>
+	      <t>
+		Obtain the Entity Configuration for the issuing Entity -
+		the Entity with the Issuer Identifer found in the Entity Statement's
+		<spanx style="verb">iss</spanx> (issuer) Claim.
+		When the <spanx style="verb">iss</spanx> and
+		<spanx style="verb">sub</spanx> Claim values match, this is
+		the Entity Statement being validated itself.
+		Otherwise, this can be obtained either from a Trust Chain or
+		by retrieving it as described in
+		<xref target="federation_configuration"/>.
+	      </t>
+	      <t>
+		The Entity Statement's
+		<spanx style="verb">kid</spanx> (Key ID) header parameter value
+		MUST be a non-zero length string and
+		MUST exactly match the <spanx style="verb">kid</spanx> value
+		for a key in the <spanx style="verb">jwks</spanx> (JWK Set) Claim
+		of the issuing Entity's Entity Configuration.
+	      </t>
+	      <t>
+		The Entity Statement's signature MUST validate using
+		the issuing Entity's key identified by the
+		<spanx style="verb">kid</spanx> value.
+	      </t>
+	    </list>
+	  </t>
+	  <t>
+	    If any of these validation steps fail,
+	    the Entity Statement MUST be rejected.
+	  </t>
+	</section>
+
+	<section anchor="ESClaimsExamples" title="Entity Statement Claims Examples">
+
         <figure>
           <preamble>
             The following is a non-normative example of the JWT Claims Set for an Entity Statement.
@@ -870,6 +964,8 @@
 }
 ]]></artwork>
         </figure>
+
+	</section>
       </section>
 
       <section title="Trust Chain" anchor="trust_chain">
@@ -10316,6 +10412,9 @@ Host: op.umu.se
 	    <spanx style="verb">description</spanx>,
 	    <spanx style="verb">keywords</spanx>, and
 	    <spanx style="verb">information_uri</spanx>.
+	  </t>
+	  <t>
+	    Fixed #84: Added sections on validating Entity Statements.
 	  </t>
 	</list>
       </t>


### PR DESCRIPTION
This PR explicitly defines how to validate entity statements.  It begins by defining how to validate all entity statements.

While currently incomplete, I will add rules for validating specific kinds of entity statements, such as those used for Explicit Registration.

Fixes #84 