### PR TITLE
Align terminology in diagram with section header

### DIFF
--- a/openid-federation-1_0.xml
+++ b/openid-federation-1_0.xml
@@ -5628,7 +5628,7 @@ Content-Type: application/json
    |                               |        Subordinate Statement about RP  |
    |                               |<---------------------------------------|
    |                               |                                        |
-   |                               | Evaluates the Trust Chain              |
+   |                               | Validates the Trust Chain              |
    |                               |--------------------------              |
    |                               |                         |              |
    |                               |<-------------------------              |


### PR DESCRIPTION
When Figure 47 says "Evaluate the Trust Chain", I think it's referring to the process described in https://openid.net/specs/openid-federation-1_0.html#section-10.2 which is called "Validating a Trust Chain". If so, it would be good to use the same wording ("Validate" rather than "Evaluate") in the Figure.