### PR TITLE
Changes to the Trust Mark validation section

### DIFF
--- a/openid-federation-1_0.xml
+++ b/openid-federation-1_0.xml
@@ -3575,7 +3575,7 @@
                 able to validate the signature of the signed delegation JWT.
               </t>
               <t>
-                The <spanx style="verb">sub</spanx> claim of MUST match the
+                The <spanx style="verb">sub</spanx> claim of the instance MUST match the
                 issuer (<spanx style="verb">iss</spanx>) of the delegation JWT
               </t>
             </list>


### PR DESCRIPTION
The fact that Trust Mark validation concerns Trust Marks represented by signed JWT needed to be stressed.

Removed statement that where present in other parts of the document.