### PR TITLE
clarify validation of trust marks not recognized within the federation

### DIFF
--- a/openid-federation-1_0.xml
+++ b/openid-federation-1_0.xml
@@ -3608,7 +3608,7 @@
             An Entity MAY choose, at its own discretion, to utilize Trust Marks presented
             to it that are not recognized within the federation, and where the
             accreditation authority is established by an out-of-band mechanism.
-            In that case, validation step 1 becomes OPTIONAL.
+            In that case, validation Step 1 becomes OPTIONAL.
           </t>
 	  <t>
 	    If trust marks are issued without an expiration time,

--- a/openid-federation-1_0.xml
+++ b/openid-federation-1_0.xml
@@ -3608,6 +3608,7 @@
             An Entity MAY choose, at its own discretion, to utilize Trust Marks presented
             to it that are not recognized within the federation, and where the
             accreditation authority is established by an out-of-band mechanism.
+            In that case, validation step 1 becomes OPTIONAL.
           </t>
 	  <t>
 	    If trust marks are issued without an expiration time,


### PR DESCRIPTION
#238 was merged. I commented on that PR: https://github.com/openid/federation/pull/238#discussion_r2275430436

This PR clarifies that for trust marks not recognized within a federation the validation step 1 is optional.
This is very logical, since this step is not possible for trust marks not recognized within a federation. However, for me it felt like a contraction to mandate the validation to be done, even thought allowing that trust marks not listed there still might be used.

Therefore, I added this statement to clarify this.