### PR TITLE
Added typ to JWS headers

### DIFF
--- a/openid-federation-1_0.xml
+++ b/openid-federation-1_0.xml
@@ -661,10 +661,10 @@
                   REQUIRED. Identifier for the type of the Trust Mark.
                   The value of this claim MUST be the same as the value of the
                   <spanx style="verb">trust_mark_type</spanx>
-                  claim contained in the Trust Mark JWT that is the value of the <spanx style="verb">trust_mark_jwt
+                  claim contained in the Trust Mark JWT that is the value of the <spanx style="verb">trust_mark
                 </spanx> claim in this object.
                 </t>
-                <t hangText="trust_mark_jwt">
+                <t hangText="trust_mark">
                   REQUIRED. A signed JSON Web Token that represents a Trust Mark.
                 </t>
               </list>
@@ -3638,7 +3638,7 @@
   "trust_marks": [
     {
      "trust_mark_type": "https://www.spid.gov.it/certification/rp",
-     "trust_mark_jwt":
+     "trust_mark":
        "eyJ0eXAiOiJ0cnVzdC1tYXJrK2p3dCIsImFsZyI6IlJTMjU2Iiwia2lkIjoia29
         zR20yd3VaaDlER21OeEF0a3VPNDBwUGpwTDMtakNmMU4tcVBPLVllVSJ9.
         eyJpc3MiOiJodHRwczovL3d3dy5hZ2lkLmdvdi5pdCIsInN1YiI6Imh0dHBzOi8
@@ -4491,7 +4491,7 @@ Host: openid.sunet.se
   },
   "trust_marks": [
     {"trust_mark_type": "https://www.spid.gov.it/certification/op/",
-     "trust_mark_jwt":
+     "trust_mark":
        "eyJ0eXAiOiJ0cnVzdC1tYXJrK2p3dCIsImFsZyI6IlJTMjU2Iiwia2lkIjoiOH
         hzdUtXaVZmd1NnSG9mMVRlNE9VZGN5NHE3ZEpyS2ZGUmxPNXhoSElhMCJ9.
         eyJpc3MiOiJodHRwczovL3d3dy5hZ2lkLmdvdi5pdCIsInN1YiI6Imh0dHBzOi


### PR DESCRIPTION
The signed JWTs in figure 6 was missing the typ claim in the headers.
This should fix that.

Fixes #236