### PR TITLE
If a loop is detected while fetching a trust chain, that chain should be ignored.

### DIFF
--- a/openid-federation-1_0.xml
+++ b/openid-federation-1_0.xml
@@ -5572,9 +5572,7 @@ Content-Type: application/json
         <t>
           Federation participants MUST NOT attempt to fetch
           Entity Statements they already have obtained during this
-          process to prevent loops.
-	  An <spanx style="verb">invalid_trust_chain</spanx> error
-	  SHOULD be returned if a loop is encountered.
+          process to prevent loops. If a loop is detected the authority hint that lead to it MUST be ignored.
         </t>
         <t>
           A successful operation will return one or more lists of


### PR DESCRIPTION
The whole process of fetching trust chains should not fail because one chain ends in a loop.