### PR TITLE
If applying the constraint allowed_entity_types results in an empty array, that is not an error.

### DIFF
--- a/openid-federation-1_0.xml
+++ b/openid-federation-1_0.xml
@@ -3317,10 +3317,6 @@
                 This MUST be done before applying Metadata Policies but after applying Metadata from a direct
                 superior's Subordinate Statement.
             </t>
-            <t>
-              If the result of applying this constraint is the empty array <spanx style="verb">[]</spanx>
-              that is not to be regarded as an error.
-          </t>
         </section>
       </section>
     </section>


### PR DESCRIPTION
Since every entity in the federation must be of the federation entity entity_type. 
The entity can still be part of the federation if the result of applying the constraint results in an empty array.