### PR TITLE
Requested status for an unknown trust mark.

### DIFF
--- a/openid-federation-1_0.xml
+++ b/openid-federation-1_0.xml
@@ -4605,7 +4605,7 @@ trust_mark=eyJ0eXAiOiJ0cnVzdC1tYXJrK2p3dCIsImFsZyI6 ...
             <xref target="error_response"/>.
           </t>
             <t>
-                If the server receive a request for the status of a trust mark it did not issue or is not aware of,
+                If the Trust Mark Issuer receives a request about the status of an unknown Trust Mark, something it did not issue or is not aware of,
                 it MUST respond with an HTTP status code 404 (Not found)
             </t>
           <t>


### PR DESCRIPTION
We need to define how a server must respond if it receives a request for the status of a trust mark it did not issue or is not aware of.

Fixes https://github.com/openid/federation/issues/249
