### PR TITLE
Extend the information returned in a Trust Mark Status response.

### DIFF
--- a/openid-federation-1_0.xml
+++ b/openid-federation-1_0.xml
@@ -4603,6 +4603,20 @@ trust_mark=eyJ0eXAiOiJ0cnVzdC1tYXJrK2p3dCIsImFsZyI6 ...
                 <vspace/>
                 REQUIRED. Boolean. Whether the Trust Mark is active or not.
               </t>
+              <t hangText="reason">
+                <vspace/>
+                OPTIONAL. String containing additional information about the error. Reasons defined by this
+                  specification are:
+                  <list style="hanging">
+                      <t hangText="revoked">
+                        <vspace/>
+                          The trust mark is revoked
+                      </t>
+                      <t hangText="invalid">
+                          Signature validation fails or instance has expired
+                      </t>
+                  </list>
+              </t>
             </list>
           </t>
 
@@ -4615,7 +4629,7 @@ trust_mark=eyJ0eXAiOiJ0cnVzdC1tYXJrK2p3dCIsImFsZyI6 ...
           <t>
             <figure>
               <preamble>
-                The following is a non-normative example of a Trust Mark status response:
+                The following is a non-normative example of a Trust Mark active status response:
               </preamble>
 	      <name>
 		Trust Mark Status Response
@@ -4626,6 +4640,25 @@ Content-Type: application/json
 
 {
   "active": true
+}
+]]></artwork>
+            </figure>
+          </t>
+          <t>
+            <figure>
+              <preamble>
+                The following is a non-normative example of a Trust Mark non-active status response:
+              </preamble>
+	      <name>
+		Trust Mark Status Response
+	      </name>
+              <artwork><![CDATA[
+200 OK
+Content-Type: application/json
+
+{
+  "active": false,
+  "reason": "revoked"
 }
 ]]></artwork>
             </figure>


### PR DESCRIPTION
To allow for more information about the cause of a non-active response.

Fixes https://github.com/openid/federation/issues/244 except for the signing responses part.