### PR TITLE
Warn about JWKS representations where they may not be understood

### DIFF
--- a/openid-federation-1_0.xml
+++ b/openid-federation-1_0.xml
@@ -78,7 +78,7 @@
       </address>
     </author>
 
-    <date day="8" month="October" year="2025"/>
+    <date day="14" month="October" year="2025"/>
 
     <workgroup>OpenID Connect Working Group</workgroup>
 
@@ -10621,7 +10621,7 @@ Host: op.umu.se
 	    and Automatic Registration.
 	  </t>
 	  <t>
-	    Applied strong requests from Sweden, specifically:
+	    Applied strong requests for Swedish government use cases, specifically:
 	    <list style="symbols">
 	      <t>
 		Added warning about using JWKS representations


### PR DESCRIPTION
Applied a strong request for Swedish government use cases, specifically:

- Added warning about using JWKS representations where they may not be understood.