### PR TITLE
Trust mark validation

### DIFF
--- a/openid-federation-1_0.xml
+++ b/openid-federation-1_0.xml
@@ -7733,8 +7733,8 @@ HTTP/1.1 302 Found
                 <t hangText="Validating Trust Marks in the Context of Validating an Entity Statement">
             <vspace/>
                     According to the text on Entity Statement Validation in <xref target="ESValidation"/>, validating a
-                    Trust Mark is confined to validating the syntax of the claim value and verifying the
-                    <spanx style="verb">trust_mark_type</spanx> connection.
+                    Trust Mark is confined to validating the syntax of the claim value,
+                    including that the <spanx style="verb">trust_mark_type</spanx> value is consistent.
                 </t>
                 <t hangText="Validating a Specific Trust Mark">
                     <vspace/>


### PR DESCRIPTION
Validating a Trust Mark is separate from using it.

A federation may have a policy that says that only trust marks issued by Trust Mark Issuers that belongs to the federation but that is separate from validating a specific Trust Mark.

Fixed https://github.com/openid/federation/issues/269, https://github.com/openid/federation/issues/270