### PR TITLE
More explicit about what to do when server validation fails in automatic registration.

### DIFF
--- a/openid-federation-1_0.xml
+++ b/openid-federation-1_0.xml
@@ -6052,6 +6052,11 @@ Content-Type: application/json
           The OP resolves the RP's Entity Configuration from the Client ID in the Authentication Request,
           following the process defined in <xref target="resolving_trust"/>.
         </t>
+          <t>
+              The RP MUST perform Trust Chain and metadata resolution for the OP, as specified in
+              <xref target="resolving_trust"/> before it sends the Authentication Request. If the resolution is not
+              successful, the RP MUST NOT attempt further interactions with the OP.
+          </t>
         <t>
           Automatic Registration has the following characteristics:
           <list style="symbols">


### PR DESCRIPTION
There was no clear language in the section dealing with automatic registration on what to do if the OP validation fails.

Fixed https://github.com/openid/federation/issues/243