### PR TITLE
Remove misleading Content-Type in Trust Mark Status response examples

### DIFF
--- a/openid-federation-1_0.xml
+++ b/openid-federation-1_0.xml
@@ -4892,12 +4892,9 @@ trust_mark=eyJ0eXAiOiJ0cnVzdC1tYXJrK2p3dCIsImFsZyI6 ...
 		a response with the status <spanx style="verb">active</spanx>:
               </preamble>
 	      <name>
-		Active Trust Mark Status Response
+		Active Trust Mark Status Response JWT Claims Set
 	      </name>
               <artwork><![CDATA[
-200 OK
-Content-Type: application/json
-
 {
   "iss": "https://www.agid.gov.it",
   "trust_mark": "eyJ0eXAiOiJ0cnVzdC1tYXJrK2p3dCIsImFsZyI6IlJTMjU2Iiwia2
@@ -4929,12 +4926,9 @@ Content-Type: application/json
 		a response with the status <spanx style="verb">revoked</spanx>:
               </preamble>
 	      <name>
-		Revoked Trust Mark Status Response
+		Revoked Trust Mark Status Response JWT Claims Set
 	      </name>
               <artwork><![CDATA[
-200 OK
-Content-Type: application/json
-
 {
   "iss": "https://www.agid.gov.it",
   "trust_mark": "eyJ0eXAiOiJ0cnVzdC1tYXJrK2p3dCIsImFsZyI6IlJTMjU2Iiwia2


### PR DESCRIPTION
In [8.4.2. ](https://openid.github.io/federation/main.html#section-8.4.2)[Trust Mark Status Response](https://openid.github.io/federation/main.html#name-trust-mark-status-response) there are two examples of responses which include this at the top:

```
200 OK
Content-Type: application/json
```

Since Trust Mark Status responses are now signed JWTs, the `Content-Type: application/json` above is misleading / wrong.

Other examples to compare to: 
* [8.6.2. ](https://openid.github.io/federation/main.html#section-8.6.2)[Trust Mark Response](https://openid.github.io/federation/main.html#name-trust-mark-response) where the example contains content type for JWS `Content-Type: application/trust-mark+jwt` and the content being token string itself.
* [8.1.2. ](https://openid.github.io/federation/main.html#section-8.1.2)[Fetch Subordinate Statement Response](https://openid.github.io/federation/main.html#name-fetch-subordinate-statement-) where only the claim set is shown (no content type designation).

This PR suggests to remove Content-Type and leave JWT Claim Set shown for Trust Mark Status response examples.
