### PR TITLE
Fix missing "use" typo

### DIFF
--- a/openid-federation-1_0.xml
+++ b/openid-federation-1_0.xml
@@ -6737,7 +6737,7 @@ HTTP/1.1 302 Found
 	    OPs SHOULD accept any client authentication method that is mutually supported
 	    and RPs MUST only use mutually supported methods.
 	    Because some OPs may be coded in such a way that
-	    they expect the RP to always the same client authentication method
+	    they expect the RP to always use the same client authentication method
 	    for subsequent interactions, note that
 	    interoperability may be improved by the RP doing so.
 	  </t>


### PR DESCRIPTION
Change "...to always the same..." > "...to always use the same...".