### PR TITLE
Clarification about Explicit Registration Responses and Entity Statements

### DIFF
--- a/openid-federation-1_0.xml
+++ b/openid-federation-1_0.xml
@@ -7374,7 +7374,7 @@ HTTP/1.1 302 Found
                   <t>
                     The RP MUST verify that the <spanx style="verb">aud</spanx> (audience)
                     Claim Value is its Entity Identifier.
-                  </t>  
+                  </t>
                   <t>
                     The RP MUST verify that the
                     <spanx style="verb">trust_anchor</spanx> represents one


### PR DESCRIPTION
Hey all!

I was reading the current state of the spec and I think we can improve the way `Explicit Registration response` is explained. In section `3.4`, it seems to be considered as a type of `Entity Statement` despite not appearing as a type in the introductory text of the section. Additionally, we have the `application/explicit-registration-response+jwt`, saying that it's not an Entity Statement.

Another point is that the explanation about the `trust_anchor` _claim_ was duplicated in sections `3.4` and `12.2.3 Successful Explicit Client Registration Response`. Furthermore, there are `Entity Registration Response` claims which are not listed on the sections `3.4` and `3.5 Entity Statement Validation`  (`aud`, for example).
 
 This ambiguity can cause confusion for readers and it's better to avoid it. IMHO, the best way of solving this is just splitting the concepts of `Entity Statement` and `Explicit Registration response`. Each one in its place on the text (and that's what I've done in this PR).
 
Anyway, I'm open for discussions :)
 
### Modifications:

-  Removed the extra explanation of `jwks` claim within Explicit Registration responses
-  Removed section `3.4 Claims Specific to Explicit Registration Responses`
-  Changed the location of the `trust_anchor` claim validation step