### PR TITLE
Make two claim registration section references more specific at Nat's suggestion

### DIFF
--- a/openid-federation-1_0.xml
+++ b/openid-federation-1_0.xml
@@ -78,7 +78,7 @@
       </address>
     </author>
 
-    <date day="24" month="November" year="2025"/>
+    <date day="25" month="November" year="2025"/>
 
     <workgroup>OpenID Connect Working Group</workgroup>
 
@@ -9296,22 +9296,6 @@ HTTP/1.1 302 Found
 	  <t>
 	    <list style="symbols">
 	      <t>
-		Claim Name: <spanx style="verb">trust_chain</spanx>
-	      </t>
-	      <t>
-		Claim Description: Trust Chain
-	      </t>
-	      <t>
-		Change Controller: OpenID Foundation Artifact Binding Working Group - openid-specs-ab@lists.openid.net
-	      </t>
-	      <t>
-		Specification Document(s): <xref target="trust_chain"/> of this specification
-	      </t>
-	    </list>
-	  </t>
-	  <t>
-	    <list style="symbols">
-	      <t>
 		Claim Name: <spanx style="verb">keys</spanx>
 	      </t>
 	      <t>
@@ -9321,7 +9305,7 @@ HTTP/1.1 302 Found
 		Change Controller: OpenID Foundation Artifact Binding Working Group - openid-specs-ab@lists.openid.net
 	      </t>
 	      <t>
-		Specification Document(s): <xref target="common_metadata"/> of this specification
+		Specification Document(s): <xref target="jwks_metadata"/> of this specification
 	      </t>
 	    </list>
 	  </t>
@@ -9338,6 +9322,22 @@ HTTP/1.1 302 Found
 	      </t>
 	      <t>
 		Specification Document(s): <xref target="trust_mark_claims"/> of this specification
+	      </t>
+	    </list>
+	  </t>
+	  <t>
+	    <list style="symbols">
+	      <t>
+		Claim Name: <spanx style="verb">trust_chain</spanx>
+	      </t>
+	      <t>
+		Claim Description: Trust Chain
+	      </t>
+	      <t>
+		Change Controller: OpenID Foundation Artifact Binding Working Group - openid-specs-ab@lists.openid.net
+	      </t>
+	      <t>
+		Specification Document(s): <xref target="resolve-response"/> of this specification
 	      </t>
 	    </list>
 	  </t>
@@ -13053,6 +13053,7 @@ Host: op.umu.se
 	Marcus Almgren,
 	Patrick Amrein,
 	Pasquale Barbaro,
+	Peter Brand,
 	Brian Campbell,
 	David Chadwick,
 	Michele D'Amico,
@@ -13082,7 +13083,6 @@ Host: op.umu.se
 	Mischa Sallé,
 	Stefan Santesson,
 	Marcos Sanz,
-	Peter Brand,
 	Michael Schwartz,
 	Giada Sciarretta,
 	Amir Sharif,


### PR DESCRIPTION
For the "keys" and "trust_chain" claims.