### PR TITLE
Describe use of "aud" Claim in Explicit Registration

### DIFF
--- a/openid-federation-1_0.xml
+++ b/openid-federation-1_0.xml
@@ -711,7 +711,7 @@
       </section>
 
       <section anchor="ss-specific"
-	       title="Claims that MUST or MAY Appear in Subordinate Statements but not Entity Configurations">
+	       title="Claims that MUST or MAY Appear in Subordinate Statements but Not in Entity Configurations">
 	<t>
 	  <list style="hanging">
             <t hangText="constraints">


### PR DESCRIPTION
Adds "aud" to the list of Entity Statement Claims and validation rules.

Addresses a gap identified while working on #289.