### PR TITLE
Describe how to enable "crit" for a kind of JWT

### DIFF
--- a/openid-federation-1_0.xml
+++ b/openid-federation-1_0.xml
@@ -78,7 +78,7 @@
       </address>
     </author>
 
-    <date day="7" month="December" year="2025"/>
+    <date day="13" month="December" year="2025"/>
 
     <workgroup>OpenID Connect Working Group</workgroup>
 
@@ -7654,6 +7654,17 @@ HTTP/1.1 302 Found
 	  Use of this Claim is OPTIONAL.
 	</t>
 	<t>
+	  Section 4 of <xref target="RFC7519"/> states that
+	  "Specific applications of JWTs will require implementations
+	  to understand and process some claims in particular ways.
+	  However, in the absence of such requirements, all claims
+	  that are not understood by implementations MUST be ignored."
+	  Thus, for the <spanx style="verb">crit</spanx> (critical) Claim to be effective,
+	  the definition for the particular kind of JWT using it MUST
+	  specify that <spanx style="verb">crit</spanx> MUST be
+	  understood and processed, as allowed in the statement above.
+	</t>
+	<t>
 	  This Claim is used in this specification as specified in <xref target="common-claims"/>
 	  to identify Claims not defined by this specification
 	  that MUST be understood and processed
@@ -11464,6 +11475,11 @@ Host: op.umu.se
 	<list style="symbols">
 	  <t>
 	    Acknowledged Pål Axelsson.
+	  </t>
+	  <t>
+	    Added description of how to enable the use of
+	    the <spanx style="verb">crit</spanx> (critical) Claim
+	    within the definition of a kind of JWT.
 	  </t>
 	</list>
       </t>


### PR DESCRIPTION
Added a description of how to enable the use of the `crit` (critical) claim within the definition of a kind of JWT, as requested by @panva.
