### PR TITLE
Improved "constraints" claim description per feedback from Nat

### DIFF
--- a/openid-federation-1_0.xml
+++ b/openid-federation-1_0.xml
@@ -7719,6 +7719,18 @@ HTTP/1.1 302 Found
 	  to represent delegation of the right to issue Trust Marks
 	  with a particular identifier.
 	</t>
+	<t>
+	  Note that the <spanx style="verb">delegation</spanx> Claim is both
+	  syntactically and semantically distinct from the existing
+	  <spanx style="verb">act</spanx> Claim <xref target="IANA.JWT.Claims"/>.
+	  <spanx style="verb">act</spanx> is a JSON object whereas
+	  <spanx style="verb">delegation</spanx> is a StringOrURI.
+	  Semantically, the Delegation JWT defined in <xref target="delegation_jwt"/>
+	  carries a signature by an issuer cryptographically proving
+	  the right to delegate to the party.
+	  The <spanx style="verb">act</spanx> Claim, carrying no signature,
+	  cannot achieve this.
+	</t>
       </section>
 
       <section anchor="logo_uriClaim" title='"logo_uri" (Logo URI) Claim'>


### PR DESCRIPTION
As [Nat wrote](https://mailarchive.ietf.org/arch/msg/jwt-reg-review/nS13c5cQEk5AhhkjKQD0iOsdyKM/):
> •	constraints ([Section 13.3](https://na01.safelinks.protection.outlook.com/?url=https%3A%2F%2Fopenid.net%2Fspecs%2Fopenid-federation-1_0.html%23name-constraints-claim&data=05%7C02%7C%7C387d879d988f4b73c13808de43a00ba6%7C84df9e7fe9f640afb435aaaaaaaaaaaa%7C1%7C0%7C639022551842342725%7CUnknown%7CTWFpbGZsb3d8eyJFbXB0eU1hcGkiOnRydWUsIlYiOiIwLjAuMDAwMCIsIlAiOiJXaW4zMiIsIkFOIjoiTWFpbCIsIldUIjoyfQ%3D%3D%7C0%7C%7C%7C&sdata=k9OA283Lzb8HLuSVZvJiK4vmYBlq1Vz7shkW5B0dYvk%3D&reserved=0)) is defined as constraints pertaining to the JWT with application-specific details, and the example states, "For instance, the constraints Claim might be used to impose material thickness limits for a physical object." It is not a very intuitive example. Explaining what is written in [Section 6.2](https://na01.safelinks.protection.outlook.com/?url=https%3A%2F%2Fopenid.net%2Fspecs%2Fopenid-federation-1_0.html%23name-constraints&data=05%7C02%7C%7C387d879d988f4b73c13808de43a00ba6%7C84df9e7fe9f640afb435aaaaaaaaaaaa%7C1%7C0%7C639022551842362674%7CUnknown%7CTWFpbGZsb3d8eyJFbXB0eU1hcGkiOnRydWUsIlYiOiIwLjAuMDAwMCIsIlAiOiJXaW4zMiIsIkFOIjoiTWFpbCIsIldUIjoyfQ%3D%3D%7C0%7C%7C%7C&sdata=AC28o%2BaAlY0GCfvrk%2BqUI5kozif7WJV1goqsi7lN2HY%3D&reserved=0) would have been clearer.

This PR removes the unintuitive "material thickness" example, instead using the example of constraints on Trust Chains as used in the specification, as suggested by @sakimura.